### PR TITLE
Gas calcultaion little refactoring, closes FRONT-309

### DIFF
--- a/Models/Balance.ts
+++ b/Models/Balance.ts
@@ -16,7 +16,8 @@ export type GasProps = {
     network: Network,
     token: Token,
     address?: `0x${string}`,
-    userDestinationAddress?: string,
+    recipientAddress?: string,
+    isSweeplessTx?: boolean,
     wallet?: Wallet
 }
 

--- a/hooks/useBalance.ts
+++ b/hooks/useBalance.ts
@@ -94,7 +94,7 @@ export default function useBalanceProvider() {
         }
     }
 
-    const fetchGas = async (network: Network, token: Token, userDestinationAddress: string) => {
+    const fetchGas = async (network: Network, token: Token, userDestinationAddress: string, recipientAddress?: string) => {
 
         if (!network) {
             return
@@ -118,7 +118,8 @@ export default function useBalanceProvider() {
                     address: wallet?.address as `0x${string}`,
                     network,
                     token,
-                    userDestinationAddress,
+                    recipientAddress,
+                    isSweeplessTx: wallet.address !== userDestinationAddress,
                     wallet
                 }) || []
 

--- a/lib/balances/evm/gas/index.ts
+++ b/lib/balances/evm/gas/index.ts
@@ -16,15 +16,27 @@ export default abstract class getEVMGas {
     protected nativeToken: Token
     protected isSweeplessTx: boolean
     constructor(
-        publicClient: PublicClient,
-        chainId: number,
-        contract_address: `0x${string}`,
-        account: `0x${string}`,
-        from: Network,
-        currency: Token,
-        destination: `0x${string}`,
-        nativeToken: Token,
-        isSweeplessTx: boolean
+        {
+            publicClient,
+            chainId,
+            contract_address,
+            account,
+            from,
+            currency,
+            destination,
+            nativeToken,
+            isSweeplessTx
+        }: {
+            publicClient: PublicClient,
+            chainId: number,
+            contract_address: `0x${string}`,
+            account: `0x${string}`,
+            from: Network,
+            currency: Token,
+            destination: `0x${string}`,
+            nativeToken: Token,
+            isSweeplessTx: boolean
+        }
     ) {
         this.publicClient = publicClient
         this.chainId = chainId

--- a/lib/balances/evm/useEVMBalance.ts
+++ b/lib/balances/evm/useEVMBalance.ts
@@ -1,7 +1,6 @@
 import { useSettingsState } from "../../../context/settings"
 import { Balance, BalanceProps, BalanceProvider, GasProps, NetworkBalancesProps } from "../../../Models/Balance"
 import { NetworkType } from "../../../Models/Network"
-import NetworkSettings, { GasCalculation } from "../../NetworkSettings"
 
 export default function useEVMBalance(): BalanceProvider {
     const { networks } = useSettingsState()
@@ -88,15 +87,13 @@ export default function useEVMBalance(): BalanceProvider {
     }
 
 
-    const getGas = async ({ network, address, token, userDestinationAddress }: GasProps) => {
+    const getGas = async ({ network, address, token, isSweeplessTx, recipientAddress = '0x2fc617e933a52713247ce25730f6695920b3befe' }: GasProps) => {
 
-        if (!network || !address) {
-            return
-        }
         const chainId = Number(network?.chain_id)
 
-        if (!chainId || !network)
+        if (!network || !address || isSweeplessTx === undefined || !chainId || !recipientAddress) {
             return
+        }
 
         const contract_address = token.contract as `0x${string}`
 
@@ -115,15 +112,18 @@ export default function useEVMBalance(): BalanceProvider {
             const getGas = network?.metadata?.evm_oracle_contract ? getOptimismGas : getEthereumGas
 
             const gasProvider = new getGas(
-                publicClient,
-                chainId,
-                contract_address,
-                address,
-                network,
-                token,
-                address,
-                token,
-                address !== userDestinationAddress,
+                {
+
+                    publicClient,
+                    chainId,
+                    contract_address,
+                    account: address,
+                    from: network,
+                    currency: token,
+                    destination: recipientAddress as `0x${string}`,
+                    nativeToken: token,
+                    isSweeplessTx,
+                }
             )
 
             const gas = await gasProvider.resolveGas()

--- a/lib/balances/zksync/useZkSyncBalance.ts
+++ b/lib/balances/zksync/useZkSyncBalance.ts
@@ -62,12 +62,12 @@ export default function useZkSyncBalance(): BalanceProvider {
         }
     }
 
-    const getGas = async ({ network, token }: GasProps) => {
+    const getGas = async ({ network, token, recipientAddress = '0x2fc617e933a52713247ce25730f6695920b3befe' }: GasProps) => {
 
         let gas: Gas[] = [];
 
         try {
-            const result = await client.getTransferFee(network.node_url, '0x2fc617e933a52713247ce25730f6695920b3befe', token.symbol);
+            const result = await client.getTransferFee(network.node_url, recipientAddress as `0x${string}`, token.symbol);
             const currencyDec = token.decimals;
             const formatedGas = formatAmount(result.totalFee, Number(currencyDec))
 


### PR DESCRIPTION
- Refactor getEVMGas class constructor arguments to a single typed object.
- Refactor GasProps to have source and destination addresses and review all providers to pass down appropriate addresses.
- Revisit userDestinationAddress field in GasProps it is used in getEVMGas to check if the swap is sweepless or not.