### PR TITLE
Use a single spritesheet instead of individual image requests for network logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ This repository contains implementation of Layerswap UI
   NEXT_PUBLIC_LS_API = https://api-dev.layerswap.cloud/
   NEXT_PUBLIC_API_KEY = mainnet #sandbox for testnets
   NEXT_PUBLIC_IDENTITY_API = https://identity-api-dev.layerswap.cloud/
+  NEXT_PUBLIC_IMAGE_STORAGE = https://layerswap-images.s3.eu-north-1.amazonaws.com/logos/
   ```
-

--- a/components/Input/NetworkFormField.tsx
+++ b/components/Input/NetworkFormField.tsx
@@ -67,7 +67,7 @@ const NetworkFormField = forwardRef(function NetworkFormField({ direction, label
     const {
         data: metadata,
         isLoading: metadataLoading,
-    } = useSWR<ApiResponse<ILogoMetadata[]> | ILogoMetadata[]>(`${metadataURL}`, apiClient.outboudFetcher, { keepPreviousData: true })
+    } = useSWR<ApiResponse<ILogoMetadata[]> | ILogoMetadata[]>(`${metadataURL}`, apiClient.outboundFetcher, { keepPreviousData: true })
 
     const [logoMetadata, setLogoMetadata] = useState<ILogoMetadata[]>([])
 

--- a/components/Input/NetworkLogo.tsx
+++ b/components/Input/NetworkLogo.tsx
@@ -24,7 +24,7 @@ const NetworkLogo: FC<Props> = (props) => {
     <div
       className={className}
       style={{
-        background: `url('${url}') -${x}px ${y}px`,
+        background: `url('${url}') -${x}px -${y}px`,
         width: `${width}px`,
         height: `${height}px`,
       }}

--- a/components/Input/NetworkLogo.tsx
+++ b/components/Input/NetworkLogo.tsx
@@ -1,0 +1,35 @@
+import { FC } from "react";
+
+import AppSettings from "../../lib/AppSettings";
+
+type Props = {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  className?: string;
+};
+
+const NetworkLogo: FC<Props> = (props) => {
+  const {
+    x = 0,
+    y = 0,
+    width = 24,
+    height = 24,
+    className = "rounded-md",
+  } = props;
+  const url = `${AppSettings.ImageStorage}spritesheet.png`;
+
+  return (
+    <div
+      className={className}
+      style={{
+        background: `url('${url}') -${x}px ${y}px`,
+        width: `${width}px`,
+        height: `${height}px`,
+      }}
+    ></div>
+  );
+};
+
+export default NetworkLogo;

--- a/components/Select/Command/CommandSelectWrapper.tsx
+++ b/components/Select/Command/CommandSelectWrapper.tsx
@@ -60,15 +60,20 @@ export default function CommandSelectWrapper<T>({
                         {
                             value?.imgSrc && <div className="flex items-center">
                                 <div className="flex-shrink-0 h-6 w-6 relative">
-                                    <Image
-                                        src={value.imgSrc}
-                                        alt="Project Logo"
-                                        height="40"
-                                        width="40"
-                                        loading="eager"
-                                        priority
-                                        className="rounded-md object-contain"
+                                     {value.logo ? (
+                                        value.logo
+                                    ) : (
+                                        // TODO: Clarify if the logo should be loaded like network logo
+                                        <Image
+                                            src={value.imgSrc}
+                                            alt="Project Logo"
+                                            height="40"
+                                            width="40"
+                                            loading="eager"
+                                            priority
+                                            className="rounded-md object-contain"
                                     />
+                                )}
                                 </div>
                             </div>
                         }

--- a/components/Select/Shared/Props/selectMenuItem.tsx
+++ b/components/Select/Shared/Props/selectMenuItem.tsx
@@ -1,3 +1,16 @@
+export interface ILogoMetadata {
+    filename: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface ILogoCoordinates {
+    x?: number;
+    y?: number;
+}
+
 export class SelectMenuItem<T> implements ISelectMenuItem {
     id: string;
     name: string;
@@ -8,6 +21,7 @@ export class SelectMenuItem<T> implements ISelectMenuItem {
     group?: string;
     details?: JSX.Element | JSX.Element[];
     badge?: JSX.Element | JSX.Element[];
+    logo?: JSX.Element | JSX.Element[];
     leftIcon?: JSX.Element | JSX.Element[];
     baseObject: T;
     constructor(baseObject: T, id: string, name: string, order: number, imgSrc: string, isAvailable: boolean, group?: string, details?: JSX.Element | JSX.Element[]) {
@@ -33,4 +47,5 @@ export interface ISelectMenuItem {
     badge?: JSX.Element | JSX.Element[];
     leftIcon?: JSX.Element | JSX.Element[];
     order?: number;
+    logo?: JSX.Element | JSX.Element[];
 }

--- a/components/Select/Shared/SelectItem.tsx
+++ b/components/Select/Shared/SelectItem.tsx
@@ -1,8 +1,8 @@
-import { ISelectMenuItem } from "./Props/selectMenuItem";
 import Image from 'next/image';
 
-export default function SelectItem({ item }: { item: ISelectMenuItem }) {
+import { ISelectMenuItem } from "./Props/selectMenuItem";
 
+export default function SelectItem({ item }: { item: ISelectMenuItem }) {
     return (
         <div className={`${item?.displayName ? "px-3" : "px-1.5"} flex items-center justify-between gap-3 w-full overflow-hidden`}>
             <div className={`${item?.displayName ? "gap-2.5" : "gap-3"} relative flex items-center  pl-1 w-full`}>
@@ -13,14 +13,19 @@ export default function SelectItem({ item }: { item: ISelectMenuItem }) {
                 }
                 <div className={`${item?.displayName ? "h-9 w-9" : "h-6 w-6"} flex-shrink-0 relative`}>
                     {item.imgSrc && (
-                        <Image
-                            src={item.imgSrc}
-                            alt="Project Logo"
-                            height="40"
-                            width="40"
-                            loading="eager"
-                            className="rounded-md object-contain"
-                        />
+                        item.logo ? (
+                            item.logo
+                        ) : (
+                            // TODO: Clarify if the logo should be loaded like network logo
+                            <Image
+                                src={item.imgSrc}
+                                alt="Project Logo"
+                                height="40"
+                                width="40"
+                                loading="eager"
+                                className="rounded-md object-contain"
+                            />
+                        )
                     )}
                 </div>
                 <div className="flex justify-between w-full">

--- a/lib/AppSettings.ts
+++ b/lib/AppSettings.ts
@@ -3,4 +3,5 @@ export default class AppSettings {
     static LayerswapApiUri?: string = process.env.NEXT_PUBLIC_LS_API
     static ExplorerURl: string = `https://www.layerswap.io/explorer/`
     static ApiVersion?: string = process.env.NEXT_PUBLIC_API_VERSION
+    static ImageStorage?: string = process.env.NEXT_PUBLIC_IMAGE_STORAGE
 }

--- a/lib/layerSwapApiClient.ts
+++ b/lib/layerSwapApiClient.ts
@@ -24,7 +24,7 @@ export default class LayerSwapApiClient {
 
     fetcher = (url: string) => this.AuthenticatedRequest<ApiResponse<any>>("GET", url)
 
-    outboudFetcher = (url: string) => this.OutboundRequest<ApiResponse<any>>("GET", url)
+    outboundFetcher = (url: string) => this.OutboundRequest<ApiResponse<any>>("GET", url)
 
     async GetRoutesAsync(direction: 'sources' | 'destinations'): Promise<ApiResponse<NetworkWithTokens[]>> {
         return await this.UnauthenticatedRequest<ApiResponse<NetworkWithTokens[]>>("GET", `/${direction}?include_unmatched=true&include_swaps=true&include_unavailable=true`)


### PR DESCRIPTION
- Updated the current implementation of network logos to use a single spritesheet instead of individual image requests.
- Modified the codebase to extract and display logos from the spritesheet.

Notes:
- The spritesheet generator can be found in the [this](https://github.com/sossargsyan/spritesheet-generator) repository.
- The GitHub action is triggered when a new commit is pushed to the main branch.
- The generator script creates a spritesheet image and metadata.json file based on the logo images in the **logos** folder.
- The GitHub action then uploads the generated spritesheet and metadata.json to an AWS S3 bucket for public access.