### PR TITLE
Add minimum priority fee per network for gas estimation

### DIFF
--- a/lib/NetworkSettings.ts
+++ b/lib/NetworkSettings.ts
@@ -48,6 +48,7 @@ const sourceOrder = [
 export default class NetworkSettings {
     ChainId?: number | string;
     BaseFeeMultiplier?: number;
+    MinPriorityFeePerGasInGwei?: number;
     AddressPlaceholder?: string;
     OrderInDestination?: number;
     OrderInSource?: number;
@@ -131,6 +132,7 @@ export default class NetworkSettings {
             AccountExplorerTemplate: 'https://optimistic.etherscan.io/address/{0}',
             GasCalculationType: GasCalculation.OptimismType,
             BaseFeeMultiplier: 1.5,
+            MinPriorityFeePerGasInGwei: 0.0001,
         };
         NetworkSettings.KnownSettings[KnownInternalNames.Networks.ScrollMainnet] = {
             ChainId: 534352,
@@ -252,7 +254,8 @@ export default class NetworkSettings {
         };
         NetworkSettings.KnownSettings[KnownInternalNames.Networks.AvalancheMainnet] = {
             ChainId: 43114,
-            BaseFeeMultiplier: 1.7
+            BaseFeeMultiplier: 1.7,
+            MinPriorityFeePerGasInGwei: 1.5,
         };
         NetworkSettings.KnownSettings[KnownInternalNames.Networks.PolygonZkMainnet] = {
             ChainId: 1101,

--- a/lib/gases/providers/evmGasProvider.ts
+++ b/lib/gases/providers/evmGasProvider.ts
@@ -2,9 +2,10 @@
 import { GasProps } from "../../../Models/Balance"
 import { NetworkType, Network, Token } from "../../../Models/Network"
 import { GasProvider } from "./types"
-import { PublicClient, TransactionSerializedEIP1559, createPublicClient, encodeFunctionData, parseEther, serializeTransaction } from "viem";
+import { PublicClient, TransactionSerializedEIP1559, createPublicClient, encodeFunctionData, parseEther, parseGwei, serializeTransaction } from "viem";
 import { erc20Abi } from "viem";
 import { formatUnits } from "viem";
+import NetworkSettings from "../../NetworkSettings";
 import { publicActionsL2 } from 'viem/op-stack'
 import resolveChain from "../../resolveChain";
 import { resolveFallbackTransport } from "../../resolveTransports";
@@ -116,9 +117,21 @@ abstract class getEVMGas {
         let maxPriorityFeePerGas = feesPerGas?.maxPriorityFeePerGas
         if (!maxPriorityFeePerGas) maxPriorityFeePerGas = await this.estimateMaxPriorityFeePerGas()
 
+        let maxFeePerGas = feesPerGas?.maxFeePerGas
+
+        const minPriorityFeeGwei = NetworkSettings.KnownSettings[this.from.name]?.MinPriorityFeePerGasInGwei
+        if (minPriorityFeeGwei && maxPriorityFeePerGas !== undefined && maxFeePerGas !== undefined) {
+            const minPriorityFee = parseGwei(minPriorityFeeGwei.toString())
+            if (maxPriorityFeePerGas < minPriorityFee) {
+                const diff = minPriorityFee - maxPriorityFeePerGas
+                maxPriorityFeePerGas = minPriorityFee
+                maxFeePerGas = maxFeePerGas + diff
+            }
+        }
+
         return {
             gasPrice,
-            maxFeePerGas: feesPerGas?.maxFeePerGas,
+            maxFeePerGas,
             maxPriorityFeePerGas: maxPriorityFeePerGas
         }
 


### PR DESCRIPTION
## Summary
- Added `MinPriorityFeePerGasInGwei` to `NetworkSettings` to set a floor on priority fees per network
- Enforced the floor in `resolveFeeData()` — if on-chain priority fee is below the minimum, it bumps both `maxPriorityFeePerGas` and `maxFeePerGas` accordingly
- Set minimum priority fees matching MetaMask's gas API: **1.5 GWEI** for Avalanche, **0.0001 GWEI** for Optimism

## Context
On Avalanche, the on-chain priority fee (`eth_maxPriorityFeePerGas`) returns ~0 GWEI, but MetaMask's gas API suggests 1.5 GWEI. This caused our gas estimates to be ~10x lower than MetaMask's, leading to failed max transfers when MetaMask blocked transactions for insufficient gas.

## Test plan
- [x] Verify AVAX gas estimate is closer to MetaMask's (~1.5 GWEI priority fee)
- [x] Verify Optimism gas estimate is unaffected (0.0001 GWEI is negligible)
- [x] Test max transfer on both networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)