### PR TITLE
Fix Ready X wallet connect for mobile

### DIFF
--- a/components/WalletProviders/StarknetProvider.tsx
+++ b/components/WalletProviders/StarknetProvider.tsx
@@ -92,14 +92,12 @@ const StarknetProvider: FC<{ children: ReactNode }> = ({ children }) => {
         const defaultConnectors: any[] = []
 
         if (!isSafari) {
-            if (!(isAndroid || isIOS)) {
-                defaultConnectors.push(
-                    new InjectedConnector({ options: { id: "argentX" } }),
-                )
-                defaultConnectors.push(
-                    new InjectedConnector({ options: { id: "keplr" } }),
-                )
-            }
+            defaultConnectors.push(
+                new InjectedConnector({ options: { id: "argentX" } }),
+            )
+            defaultConnectors.push(
+                new InjectedConnector({ options: { id: "keplr" } }),
+            )
             defaultConnectors.push(
                 new InjectedConnector({ options: { id: "braavos" } }),
             )


### PR DESCRIPTION
- Removed conditional checks for Android and iOS in the default connector setup.