### PR TITLE
Fix switchAccount/switchChain connector lookup for dynamic wallets

### DIFF
--- a/lib/wallets/evm/useEVM.ts
+++ b/lib/wallets/evm/useEVM.ts
@@ -355,8 +355,17 @@ export default function useEVM(): WalletProvider {
         }).filter(w => w !== undefined)
     }, [activeConnection, config, connectedWalletsKey])
 
+    const resolveWalletConnector = useCallback((wallet: Wallet) => {
+        const connections = getConnections(config)
+        return connections.find(c => c.connector.name === wallet.id)?.connector
+            ?? connections.find(c =>
+                c.connector.id === HIDDEN_WALLETCONNECT_ID
+                && c.accounts.some(a => a.toLowerCase() === wallet.address.toLowerCase())
+            )?.connector
+    }, [config])
+
     const switchAccount = useCallback(async (wallet: Wallet, address: string) => {
-        const connector = getConnections(config).find(c => c.connector.name === wallet.id)?.connector
+        const connector = resolveWalletConnector(wallet)
         if (!connector)
             throw new Error("Connector not found")
         const { accounts } = await switchAccountAsync({ connector })
@@ -364,10 +373,10 @@ export default function useEVM(): WalletProvider {
         if (!account)
             throw new Error("Account not found")
         setActiveAddress(account)
-    }, [config, switchAccountAsync])
+    }, [resolveWalletConnector, switchAccountAsync])
 
     const switchChain = async (wallet: Wallet, chainId: string | number) => {
-        const connector = getConnections(config).find(c => c.connector.name === wallet.id)?.connector
+        const connector = resolveWalletConnector(wallet)
         if (!connector)
             throw new Error("Connector not found")
 


### PR DESCRIPTION
For dynamic wallets connected via the shared hidden WalletConnect connector, wallet.id holds the dynamic wallet's display name rather than the wagmi connector.name, so the existing name-based lookup always failed with "Connector not found".

Match by connector.name first (preserving correct behavior when the same address is connected through multiple wallets), then fall back to matching by address within the hidden WalletConnect connector.