### PR TITLE
Manage wallets shortcut in swap history filter

### DIFF
--- a/components/Input/Address/AddressPicker/AddressWithIcon.tsx
+++ b/components/Input/Address/AddressPicker/AddressWithIcon.tsx
@@ -230,7 +230,7 @@ const AddressDetailsPopover: FC<AddressDetailsPopoverProps> = ({ address, networ
 
     return (
         <div onClick={(e) => e.stopPropagation()}>
-            <Popover open={isPopoverOpen} onOpenChange={handlePopoverChange} modal={true}>
+            <Popover open={isPopoverOpen} onOpenChange={handlePopoverChange}>
                 <PopoverTrigger asChild>
                     <div>
                         <Tooltip onOpenChange={onTooltipOpenChange}>
@@ -262,6 +262,12 @@ const AddressDetailsPopover: FC<AddressDetailsPopoverProps> = ({ address, networ
                     avoidCollisions={true}
                     collisionPadding={8}
                     sticky="always"
+                    onInteractOutside={(e) => {
+                        e.detail.originalEvent.stopPropagation()
+                    }}
+                    onPointerDownOutside={(e) => {
+                        e.detail.originalEvent.stopPropagation()
+                    }}
                 >
                     {showDetails && (title || description) && (
                         <div>

--- a/components/SwapHistory/Filters/WalletsDropdown.tsx
+++ b/components/SwapHistory/Filters/WalletsDropdown.tsx
@@ -1,10 +1,12 @@
 import { FC, useMemo, useState } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Settings2 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '../../shadcn/popover'
 import { Wallet } from '@/Models/WalletProvider'
 import { Address } from '@/lib/address'
 import CheckboxRow from './CheckboxRow'
 import { filterChipClasses } from './chipStyles'
+import VaulDrawer from '../../modal/vaulModal'
+import WalletsList from '../../Wallet/WalletsList'
 
 type WalletsDropdownProps = {
     wallets: Wallet[]
@@ -22,6 +24,7 @@ type Row = {
 
 const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, selectedAddresses, toggle, count }) => {
     const [open, setOpen] = useState(false)
+    const [manageOpen, setManageOpen] = useState(false)
     const disabled = wallets.length === 0
     const label = count > 0 ? `Wallets (${count})` : 'Wallets'
 
@@ -44,28 +47,49 @@ const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, selectedAddresses,
     }, [wallets])
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
-            <PopoverTrigger asChild>
-                <button type="button" disabled={disabled} className={filterChipClasses(count > 0)}>
-                    <span>{label}</span>
-                    <ChevronDown className="w-4 h-4" />
-                </button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="p-1 w-64 overflow-hidden">
-                <div className="max-h-72 overflow-y-auto styled-scroll">
-                    {rows.map(({ address, walletLabel, short, Icon }) => (
-                        <CheckboxRow
-                            key={address}
-                            checked={selectedAddresses.includes(address)}
-                            onToggle={() => toggle(address)}
-                            icon={Icon ? <Icon className="w-5 h-5" /> : null}
-                            label={walletLabel}
-                            sublabel={short}
-                        />
-                    ))}
-                </div>
-            </PopoverContent>
-        </Popover>
+        <>
+            <Popover open={open} onOpenChange={setOpen}>
+                <PopoverTrigger asChild>
+                    <button type="button" disabled={disabled} className={filterChipClasses(count > 0)}>
+                        <span>{label}</span>
+                        <ChevronDown className="w-4 h-4" />
+                    </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="p-1 w-64 overflow-hidden">
+                    <div className="max-h-72 overflow-y-auto styled-scroll">
+                        {rows.map(({ address, walletLabel, short, Icon }) => (
+                            <CheckboxRow
+                                key={address}
+                                checked={selectedAddresses.includes(address)}
+                                onToggle={() => toggle(address)}
+                                icon={Icon ? <Icon className="w-5 h-5" /> : null}
+                                label={walletLabel}
+                                sublabel={short}
+                            />
+                        ))}
+                    </div>
+                    {rows.length > 0 ? <div className="mx-3 my-1 h-px bg-secondary-400" /> : null}
+                    <button
+                        type="button"
+                        onClick={() => { setOpen(false); setManageOpen(true) }}
+                        className="w-full flex items-center gap-2 px-3 py-2 rounded-2xl text-sm text-primary-text hover:bg-secondary-400"
+                    >
+                        <Settings2 className="w-4 h-4" />
+                        <span>Manage wallets</span>
+                    </button>
+                </PopoverContent>
+            </Popover>
+            <VaulDrawer
+                show={manageOpen}
+                setShow={setManageOpen}
+                header={`Connected wallets`}
+                modalId="connectedWallets"
+            >
+                <VaulDrawer.Snap id="item-1">
+                    <WalletsList wallets={wallets} />
+                </VaulDrawer.Snap>
+            </VaulDrawer>
+        </>
     )
 }
 


### PR DESCRIPTION
## Summary

- Add a **Manage wallets** button at the bottom of the Wallets filter dropdown on the swap history page; it opens the existing Connected wallets drawer (`VaulDrawer` + `WalletsList`), so users can connect or disconnect wallets without leaving the filter.
- Bundled fix: prevent the address-details popover (`AddressDetailsPopover`) from also closing its surrounding `VaulDrawer` on outside-click. Switched it off `modal={true}` and stopped propagation on `onInteractOutside` / `onPointerDownOutside`.

## Screenshot

<img width="343" height="268" alt="Screenshot 2026-04-27 at 21 22 16" src="https://github.com/user-attachments/assets/0ea56b5b-a086-4cb9-b3af-aeb6e56ef3b6" />

## Test plan

- [ ] Open the swap history page with at least one connected wallet.
- [ ] Open the **Wallets** filter — verify the new **Manage wallets** row at the bottom, separated by a divider.
- [ ] Click **Manage wallets** — Connected wallets drawer opens with the existing **+ Connect new wallet** flow and disconnect controls.
- [ ] Connect a new wallet from the drawer — close the drawer; reopen the filter — new wallet appears as a checkbox row.
- [ ] Disconnect a wallet from the drawer — reopen the filter — wallet is gone, any selected addresses for it are cleared.
- [ ] Inside the drawer, click an address to open its details popover; click elsewhere inside the drawer — only the popover closes, drawer stays open.