### PR TITLE
Dev to main

### DIFF
--- a/components/LayerswapMenu/index.tsx
+++ b/components/LayerswapMenu/index.tsx
@@ -1,5 +1,5 @@
 import { MenuIcon, ChevronLeft } from "lucide-react";
-import { FC, useEffect, useState } from "react";
+import { FC } from "react";
 import IconButton from "../buttons/iconButton";
 import { FormWizardProvider, useFormWizardaUpdate, useFormWizardState } from "../../context/formWizardProvider";
 import { MenuStep } from "../../Models/Wizard";
@@ -10,13 +10,20 @@ import { NextRouter, useRouter } from "next/router";
 import { resolvePersistantQueryParams } from "../../helpers/querryHelper";
 import HistoryList from "../SwapHistory/History";
 import { Modal, ModalContent } from "@/components/modal/modalWithoutAnimation";
+import { useControllableState } from "../modal/vaul/use-controllable-state";
 
 const Comp = () => {
     const router = useRouter();
-    const [isOpen, setIsOpen] = useState(false)
-
     const { goBack, currentStepName } = useFormWizardState()
     const { goToStep } = useFormWizardaUpdate()
+
+    const [isOpen = false, setIsOpen] = useControllableState<boolean>({
+        onChange: (open) => {
+            if (!open) return
+            goToStep(MenuStep.Menu)
+            clearMenuPath(router)
+        },
+    });
 
     const goBackToMenuStep = () => { goToStep(MenuStep.Menu, "back"); clearMenuPath(router) }
 
@@ -24,13 +31,6 @@ const Comp = () => {
         goToStep(step)
         setMenuPath(path, router)
     }
-
-    useEffect(() => {
-        if (isOpen) {
-            goToStep(MenuStep.Menu)
-            clearMenuPath(router)
-        }
-    }, [isOpen, goToStep, router])
 
     return <>
         <div className="text-secondary-text cursor-pointer relative">

--- a/components/SwapHistory/Filters/WalletsDropdown.tsx
+++ b/components/SwapHistory/Filters/WalletsDropdown.tsx
@@ -1,17 +1,15 @@
 import { FC, useMemo, useState } from 'react'
-import { ChevronDown, Pencil, Settings2 } from 'lucide-react'
+import { ChevronDown, Settings2 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '../../shadcn/popover'
 import { Wallet } from '@/Models/WalletProvider'
 import { Address } from '@/lib/address'
 import CheckboxRow from './CheckboxRow'
 import { filterChipClasses } from './chipStyles'
-import type { ManualDestAddress } from '@/stores/manualDestAddressesStore'
 import VaulDrawer from '../../modal/vaulModal'
 import WalletsList from '../../Wallet/WalletsList'
 
 type WalletsDropdownProps = {
     wallets: Wallet[]
-    manualAddresses: ManualDestAddress[]
     selectedAddresses: string[]
     toggle: (address: string) => void
     count: number
@@ -24,10 +22,10 @@ type Row = {
     icon: React.ReactNode
 }
 
-const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, manualAddresses, selectedAddresses, toggle, count }) => {
+const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, selectedAddresses, toggle, count }) => {
     const [open, setOpen] = useState(false)
     const [manageOpen, setManageOpen] = useState(false)
-    const disabled = wallets.length === 0 && manualAddresses.length === 0
+    const disabled = wallets.length === 0
     const label = count > 0 ? `Wallets (${count})` : 'Wallets'
 
     const rows = useMemo<Row[]>(() => {
@@ -47,19 +45,8 @@ const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, manualAddresses, s
                 })
             }
         }
-        for (const m of manualAddresses) {
-            const addr = new Address(m.address, null, m.providerName)
-            if (seen.has(addr.normalized)) continue
-            seen.add(addr.normalized)
-            out.push({
-                address: m.address,
-                label: 'Manually added',
-                short: addr.toShortString(),
-                icon: <Pencil className="w-4 h-4" />,
-            })
-        }
         return out
-    }, [wallets, manualAddresses])
+    }, [wallets])
 
     return (
         <>

--- a/components/SwapHistory/Filters/index.tsx
+++ b/components/SwapHistory/Filters/index.tsx
@@ -5,7 +5,6 @@ import WalletsDropdown from './WalletsDropdown'
 import NetworksDropdown from './NetworksDropdown'
 import ClearAllButton from './ClearAllButton'
 import { FilterNetworkOption } from './types'
-import type { ManualDestAddress } from '@/stores/manualDestAddressesStore'
 
 type FiltersProps = {
     searchQuery: string
@@ -15,7 +14,6 @@ type FiltersProps = {
     networkNames: string[]
     toggleNetworkName: (name: string) => void
     wallets: Wallet[]
-    manualAddresses: ManualDestAddress[]
     networks: FilterNetworkOption[]
     onClearAll: () => void
 }
@@ -28,7 +26,6 @@ const Filters: FC<FiltersProps> = ({
     networkNames,
     toggleNetworkName,
     wallets,
-    manualAddresses,
     networks,
     onClearAll,
 }) => {
@@ -47,7 +44,6 @@ const Filters: FC<FiltersProps> = ({
             <div className="flex flex-wrap items-center gap-2">
                 <WalletsDropdown
                     wallets={wallets}
-                    manualAddresses={manualAddresses}
                     selectedAddresses={walletAddresses}
                     toggle={toggleWalletAddress}
                     count={walletAddresses.length}

--- a/components/SwapHistory/History.tsx
+++ b/components/SwapHistory/History.tsx
@@ -24,7 +24,7 @@ import { SwapResponse } from '@/lib/apiClients/layerSwapApiClient';
 import { SwapDataProvider, SwapDataStateContext } from '@/context/swap';
 import type { Wallet } from '@/Models/WalletProvider';
 import { useSwapTransactionStore } from '@/stores/swapTransactionStore';
-import { useManualDestAddressesStore } from '@/stores/manualDestAddressesStore';
+import AppSettings from '@/lib/AppSettings';
 
 type ListProps = {
     statuses?: string | number;
@@ -35,7 +35,6 @@ type ListProps = {
 const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
     const { networks } = useSettingsState()
     const { wallets } = useWallet()
-    const manualDestAddresses = useManualDestAddressesStore(s => s.manualDestAddresses)
 
     const {
         searchQuery, setSearchQuery,
@@ -43,7 +42,7 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
         networkNames, toggleNetworkName,
         clearFilters,
         filtersActive,
-    } = useHistoryFilters({ wallets, manualAddresses: manualDestAddresses })
+    } = useHistoryFilters({ wallets })
 
     const { allAddresses, normalizedByRaw } = useMemo(() => {
         const all = new Set<string>()
@@ -56,13 +55,8 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
                 map.set(addr, normalized)
             }
         }
-        for (const m of manualDestAddresses) {
-            const normalized = new Address(m.address, null, m.providerName).normalized
-            all.add(normalized)
-            map.set(m.address, normalized)
-        }
         return { allAddresses: Array.from(all), normalizedByRaw: map }
-    }, [wallets, networks, manualDestAddresses])
+    }, [wallets, networks])
 
     const effectiveAddresses = useMemo(() => {
         if (!selectedWalletAddrs || selectedWalletAddrs.length === 0) return allAddresses
@@ -90,12 +84,11 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
             networkNames={networkNames}
             toggleNetworkName={toggleNetworkName}
             wallets={wallets}
-            manualAddresses={manualDestAddresses}
             networks={networkOptions}
             onClearAll={clearFilters}
         />
     ), [
-        wallets, manualDestAddresses,
+        wallets,
         networkOptions,
         searchQuery, setSearchQuery,
         walletAddresses, toggleWalletAddress,
@@ -103,7 +96,7 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
         clearFilters,
     ])
 
-    const noAccounts = wallets.length === 0 && manualDestAddresses.length === 0
+    const noAccounts = wallets.length === 0
 
     return (
         <div className="relative flex flex-col h-full min-h-0">
@@ -385,7 +378,7 @@ const SwapsList: FC<SwapsListProps> = ({
 
 type HistoryEmptyStateProps = {
     title: string
-    description: string
+    description: ReactNode
     action?: ReactNode
 }
 
@@ -424,7 +417,13 @@ const BlankHistory = ({ onNewTransferClick }: BlankHistoryProps) => (
 const ConnectWalletCard = () => (
     <HistoryEmptyState
         title="Connect wallet"
-        description="In order to see your transfer history you need to connect your wallet."
+        description={
+            <>
+                <span>In order to see your transfer history you need to connect your wallet. You can also see history by address in the </span>
+                <a href={AppSettings.ExplorerURl} target="_blank" rel="noopener noreferrer" aria-label="Open Layerswap explorer (opens in new tab)" className="text-primary hover:underline">explorer</a>
+                <span>.</span>
+            </>
+        }
         action={
             <ConnectButton>
                 <div className="flex items-center gap-2 text-base text-secondary-text font-normal bg-secondary-500 hover:bg-secondary-400 py-2 px-3 rounded-lg">

--- a/hooks/useHistoryFilters.ts
+++ b/hooks/useHistoryFilters.ts
@@ -1,13 +1,11 @@
 import { useCallback, useMemo, useState } from 'react'
 import { Wallet } from '@/Models/WalletProvider'
-import type { ManualDestAddress } from '@/stores/manualDestAddressesStore'
 
 type Args = {
     wallets: Wallet[]
-    manualAddresses: ManualDestAddress[]
 }
 
-export function useHistoryFilters({ wallets, manualAddresses }: Args) {
+export function useHistoryFilters({ wallets }: Args) {
     const [searchQuery, setSearchQuery] = useState('')
     const [walletAddresses, setWalletAddresses] = useState<string[]>([])
     const [networkNames, setNetworkNames] = useState<string[]>([])
@@ -33,9 +31,8 @@ export function useHistoryFilters({ wallets, manualAddresses }: Args) {
     const knownAddresses = useMemo(() => {
         const s = new Set<string>()
         for (const w of wallets) for (const a of w.addresses) s.add(a)
-        for (const m of manualAddresses) s.add(m.address)
         return s
-    }, [wallets, manualAddresses])
+    }, [wallets])
 
     const selectedWalletAddrs = useMemo<string[] | null>(() => {
         const addrs = walletAddresses.filter(a => knownAddresses.has(a))

--- a/stores/manualDestAddressesStore.ts
+++ b/stores/manualDestAddressesStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { createJSONStorage, persist } from 'zustand/middleware'
 import { Address as AddressClass } from '@/lib/address'
 
 export type ManualDestAddress = {
@@ -13,7 +12,7 @@ interface ManualDestAddressesState {
     removeManualDestAddress: (address: string, providerName: string) => void
 }
 
-export const useManualDestAddressesStore = create<ManualDestAddressesState>()(persist((set) => ({
+export const useManualDestAddressesStore = create<ManualDestAddressesState>()((set) => ({
     manualDestAddresses: [],
     addManualDestAddress: (entry) => set(state => ({
         manualDestAddresses: state.manualDestAddresses.some(
@@ -29,7 +28,4 @@ export const useManualDestAddressesStore = create<ManualDestAddressesState>()(pe
                 && AddressClass.equals(e.address, address, null, providerName))
         )
     })),
-}), {
-    name: 'manualDestAddresses',
-    storage: createJSONStorage(() => localStorage),
 }))


### PR DESCRIPTION
Manual destination addresses are now session-scoped (in-memory Zustand store, no `persist` middleware) and no longer used on the History page — History operates purely on connected wallets. The "Connect wallet" empty state now links users to the public explorer for address-based history. Also fixes LayerswapMenu modal close adding spurious browser history entries (`onChange` now guards on open and uses `clearMenuPath`).