### PR TITLE
Add Easy deposit banner and redesign deposit-address card

### DIFF
--- a/components/Swap/Form/DepositAddressForm.tsx
+++ b/components/Swap/Form/DepositAddressForm.tsx
@@ -4,7 +4,7 @@ import { Widget } from "@/components/Widget/Index";
 import { SwapFormValues } from "@/components/DTOs/SwapFormValues";
 import { Form, useFormikContext } from "formik";
 import { Partner } from "@/Models/Partner";
-import { ChevronDown, ChevronUp, Clock, Copy, Check, Plus} from "lucide-react";
+import { ChevronDown, ChevronUp, Copy, Check, Plus} from "lucide-react";
 import { useValidationContext } from "@/context/validationContext";
 import useWallet from "@/hooks/useWallet";
 import { Network, NetworkRoute, NetworkRouteToken, Token } from "@/Models/Network";
@@ -40,6 +40,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { AnimatePresence, motion } from "framer-motion";
 import { formatPercent } from "@/components/utils/formatPercent";
 import { formatUsd } from "@/components/utils/formatUsdAmount";
+import EasyDepositBanner from "./EasyDepositBanner";
 
 type Props = {
     partner?: Partner;
@@ -79,7 +80,7 @@ const DepositAddressForm: FC<Props> = () => {
     useEffect(() => {
         if (hasWallet) return;
         if (isWalletModalOpenRef.current) return;
-        connect(undefined, { dismissible: false });
+        connect(undefined, { dismissible: false, topContent: <EasyDepositBanner variant="modal" currentStepIndex={0} />, fullHeight: true, hideHeader: true });
         return () => { cancel(); };
     }, [hasWallet, connect, cancel]);
 
@@ -197,6 +198,8 @@ const DepositAddressForm: FC<Props> = () => {
                     <Widget.Content>
                         <div className="w-full flex flex-col justify-between flex-1 relative min-h-[240px]">
                             <div className="flex flex-col w-full gap-3">
+
+                                <EasyDepositBanner />
 
                                 {/* Source (Pay from) */}
                                 <PayFromPicker
@@ -646,23 +649,35 @@ const DepositAddressInfo: FC<DepositAddressInfoProps> = ({
         <div className="flex flex-col gap-3">
             {/* Deposit address + QR */}
             <div>
-                <div className="bg-secondary-500 rounded-xl p-3.5">
-                    <div className="flex items-center bg-secondary-300 rounded-lg">
-                        <div className="flex-1 min-w-0 flex justify-center">
-                            {isCreatingSwap || !depositAddress ? (
-                                <span className="inline-block bg-secondary-400 h-6 rounded animate-pulse w-32" />
-                            ) : (
-                                <button
-                                    type="button"
-                                    onClick={handleCopy}
-                                    aria-label={copied ? 'Copied' : 'Copy deposit address'}
-                                    className="group/copy cursor-pointer text-center px-2 max-w-[200px]"
-                                >
-                                    <span
-                                        className={`font-mono text-base break-all leading-snug transition-colors ${copied ? 'text-primary-text' : 'text-secondary-text group-hover/copy:text-primary-text'}`}
-                                    >
-                                        <span className="text-primary-text font-medium">{depositAddressParts.start}</span>
-                                        {depositAddressParts.middle}
+                <div className="flex items-stretch bg-secondary-400 rounded-xl overflow-hidden">
+                    <div className="shrink-0 bg-white p-1.5 flex items-center">
+                        {isCreatingSwap || !depositAddress ? (
+                            <div className="h-[140px] w-[140px] bg-secondary-100 rounded animate-pulse" />
+                        ) : (
+                            <QRCodeSVG
+                                className="rounded"
+                                value={depositAddress}
+                                includeMargin={false}
+                                size={140}
+                                level="H"
+                            />
+                        )}
+                    </div>
+                    <div className="flex-1 min-w-0 p-3.5 flex items-center justify-center">
+                        {isCreatingSwap || !depositAddress ? (
+                            <span className="inline-block bg-secondary-300 h-6 rounded animate-pulse w-32" />
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={handleCopy}
+                                aria-label={copied ? 'Copied' : 'Copy deposit address'}
+                                className="group/copy cursor-pointer text-left"
+                                style={{ maxWidth: `${Math.ceil(depositAddress.length / 3) + 2}ch` }}
+                            >
+                                <span className={`font-mono text-lg leading-snug block break-all transition-colors ${copied ? 'text-primary-text' : 'text-secondary-text group-hover/copy:text-primary-text'}`}>
+                                    <span className="text-primary-text font-medium">{depositAddressParts.start}</span>
+                                    {depositAddressParts.middle}
+                                    <span className="whitespace-nowrap">
                                         <span className="text-primary-text font-medium">{depositAddressParts.end}</span>
                                         <span className="inline-flex items-center align-middle ml-1 w-4 h-4 relative">
                                             <AnimatePresence mode="wait" initial={false}>
@@ -692,34 +707,26 @@ const DepositAddressInfo: FC<DepositAddressInfoProps> = ({
                                             </AnimatePresence>
                                         </span>
                                     </span>
-                                </button>
-                            )}
-                        </div>
-                        <div className="shrink-0 bg-white p-1.5 rounded-lg border-4 border-secondary-500">
-                            {isCreatingSwap || !depositAddress ? (
-                                <div className="h-[140px] w-[140px] bg-secondary-100 rounded animate-pulse" />
-                            ) : (
-                                <QRCodeSVG
-                                    className="rounded"
-                                    value={depositAddress}
-                                    includeMargin={false}
-                                    size={140}
-                                    level="H"
-                                />
-                            )}
-                        </div>
+                                </span>
+                            </button>
+                        )}
                     </div>
                 </div>
             </div>
 
-            {/* Fee + ETA summary */}
-            <div className="bg-secondary-500 rounded-xl px-3.5 py-3">
-                {isQuoteLoading && !bestQuote ? (
+            {/* Loading skeleton */}
+            {isQuoteLoading && !bestQuote && (
+                <div className="bg-secondary-500 rounded-xl px-3.5 py-3">
                     <div className="flex items-center gap-3 animate-pulse">
                         <div className="h-4 bg-secondary-400 rounded w-24" />
                         <div className="h-4 bg-secondary-400 rounded w-16" />
                     </div>
-                ) : sortedTiers.length === 1 ? (
+                </div>
+            )}
+
+            {/* Min/Max container */}
+            {!(isQuoteLoading && !bestQuote) && (minDepositDisplay || maxDepositDisplay) && (
+                <div className="bg-secondary-500 rounded-xl px-3.5 py-3">
                     <div className="flex flex-col gap-1.5 text-xs text-secondary-text">
                         {minDepositDisplay && (
                             <div className="flex items-center justify-between">
@@ -733,37 +740,17 @@ const DepositAddressInfo: FC<DepositAddressInfoProps> = ({
                                 <span className="text-primary-text">{maxDepositDisplay}</span>
                             </div>
                         )}
-                        <div className={`flex items-center gap-3 ${(minDepositDisplay || maxDepositDisplay) ? 'border-t border-secondary-400/40 pt-2 mt-0.5' : ''}`}>
-                            <span className="flex items-center gap-1">
-                                <span>{formatFee(sortedTiers[0].total_percentage_fee, sortedTiers[0].total_fixed_fee_in_usd)}</span>
-                            </span>
-                            {bestQuote && (
-                                <span className="flex items-center gap-1">
-                                    <Clock className="h-3 w-3" />
-                                    <span>{formatCompletionTime(bestQuote.avg_completion_milliseconds)}</span>
-                                </span>
-                            )}
-                        </div>
                     </div>
-                ) : sortedTiers.length > 1 && sourceToken ? (
-                    isFeesExpanded ? (
+                </div>
+            )}
+
+            {/* Fees + Est. time container */}
+            {!(isQuoteLoading && !bestQuote) && sortedTiers.length >= 1 && (
+                <div className="bg-secondary-500 rounded-xl px-3.5 py-3">
+                    {isFeesExpanded && sortedTiers.length > 1 && sourceToken ? (
                         <div className="flex flex-col gap-2 text-xs">
-                            {minDepositDisplay && (
-                                <div className="flex items-center justify-between text-secondary-text">
-                                    <span>Minimum</span>
-                                    <span className="text-primary-text">{minDepositDisplay}</span>
-                                </div>
-                            )}
-                            {maxDepositDisplay && (
-                                <div className="flex items-center justify-between text-secondary-text">
-                                    <span>Maximum</span>
-                                    <span className="text-primary-text">{maxDepositDisplay}</span>
-                                </div>
-                            )}
-                            <div className={`flex items-center justify-between text-secondary-text ${(minDepositDisplay || maxDepositDisplay) ? 'border-t border-secondary-400/40 pt-2' : ''}`}>
-                                <span className="flex items-center gap-1">
-                                    <span>{"Fees by amount"}</span>
-                                </span>
+                            <div className="flex items-center justify-between text-secondary-text">
+                                <span>{"Fees by amount"}</span>
                                 <button
                                     type="button"
                                     onClick={() => setIsFeesExpanded(false)}
@@ -773,7 +760,7 @@ const DepositAddressInfo: FC<DepositAddressInfoProps> = ({
                                     <ChevronUp className="h-4 w-4" />
                                 </button>
                             </div>
-                            <div className="flex flex-col gap-0.5 border-t border-secondary-400/40 pt-2 pl-4">
+                            <div className="flex flex-col gap-0.5 border-t border-secondary-400/40 pt-2">
                                 {sortedTiers.map((tier, idx) => {
                                     const range = formatTierRange(
                                         tier,
@@ -800,42 +787,31 @@ const DepositAddressInfo: FC<DepositAddressInfoProps> = ({
                             </div>
                         </div>
                     ) : (
-                        <div className="flex flex-col gap-1.5 text-xs text-secondary-text">
-                            {minDepositDisplay && (
-                                <div className="flex items-center justify-between">
-                                    <span>Minimum</span>
-                                    <span className="text-primary-text">{minDepositDisplay}</span>
-                                </div>
-                            )}
-                            {maxDepositDisplay && (
-                                <div className="flex items-center justify-between">
-                                    <span>Maximum</span>
-                                    <span className="text-primary-text">{maxDepositDisplay}</span>
-                                </div>
-                            )}
-                            <div className={`flex items-center gap-3 ${(minDepositDisplay || maxDepositDisplay) ? 'border-t border-secondary-400/40 pt-2 mt-0.5' : ''}`}>
+                        <div className="flex items-start justify-between gap-3 text-xs">
+                            <span className="text-secondary-text shrink-0">Fees</span>
+                            <div className="flex flex-col items-end gap-1 min-w-0">
                                 <span className="flex items-center gap-1 min-w-0">
                                     <span className="text-primary-text">{formatFee(sortedTiers[0].total_percentage_fee, sortedTiers[0].total_fixed_fee_in_usd)}</span>
-                                    <span className="truncate">{`· ${formatTierRange(sortedTiers[0], true, false, sourceToken)}`}</span>
+                                    {sortedTiers.length > 1 && sourceToken && (
+                                        <span className="text-secondary-text truncate">{`· ${formatTierRange(sortedTiers[0], true, false, sourceToken)}`}</span>
+                                    )}
                                 </span>
-                                <span className="flex items-center gap-1 ml-auto shrink-0">
-                                    <Clock className="h-3 w-3" />
-                                    <span>{formatCompletionTime(sortedTiers[0].avg_completion_milliseconds)}</span>
-                                </span>
+                                {sortedTiers.length > 1 && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setIsFeesExpanded(true)}
+                                        className="flex items-center gap-1 text-secondary-text hover:text-primary-text transition-colors"
+                                        aria-label="Show fee for larger sends"
+                                    >
+                                        <span>{`${formatFee(sortedTiers[1].total_percentage_fee, sortedTiers[1].total_fixed_fee_in_usd)} for larger sends`}</span>
+                                        <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+                                    </button>
+                                )}
                             </div>
-                            <button
-                                type="button"
-                                onClick={() => setIsFeesExpanded(true)}
-                                className="flex items-center justify-between w-full hover:text-primary-text transition-colors border-t border-secondary-400/40 pt-2 mt-0.5 rounded-t-none"
-                                aria-label="Show fee for larger sends"
-                            >
-                                <span>{`${formatFee(sortedTiers[1].total_percentage_fee, sortedTiers[1].total_fixed_fee_in_usd)} for larger sends`}</span>
-                                <ChevronDown className="h-4 w-4 shrink-0" />
-                            </button>
                         </div>
-                    )
-                ) : null}
-            </div>
+                    )}
+                </div>
+            )}
         </div>
     );
 };

--- a/components/Swap/Form/EasyDepositBanner.tsx
+++ b/components/Swap/Form/EasyDepositBanner.tsx
@@ -1,0 +1,157 @@
+import { ComponentType, FC, SVGProps, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, Coins, Send } from "lucide-react";
+import clsx from "clsx";
+import DepositTabIcon from "@/components/icons/DepositTabIcon";
+import WalletIcon from "@/components/icons/WalletIcon";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+type Step = {
+    title: string;
+    description: string;
+    Icon: IconComponent;
+};
+
+const STEPS: Step[] = [
+    {
+        title: "Choose your wallet",
+        description: "The wallet where you want to receive the bridged assets.",
+        Icon: WalletIcon,
+    },
+    {
+        title: "Select tokens",
+        description: "Pick what you'll send and what you'll receive.",
+        Icon: Coins,
+    },
+    {
+        title: "Send from any wallet or CEX",
+        description: "Transfer to your deposit address from MetaMask, Binance, Coinbase — anywhere.",
+        Icon: Send,
+    },
+];
+
+type Props = {
+    variant?: "inline" | "modal";
+    currentStepIndex?: number;
+};
+
+const EasyDepositBanner: FC<Props> = ({ variant = "inline", currentStepIndex }) => {
+    const [showAllSteps, setShowAllSteps] = useState(false);
+
+    const isModal = variant === "modal";
+    const stepsVisible = isModal || showAllSteps;
+    const peek = isModal && !showAllSteps;
+
+    return (
+        <div className="relative rounded-xl bg-secondary-500 overflow-hidden">
+            <div className="relative p-3.5">
+                <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/20">
+                        <DepositTabIcon className="h-5 w-5 text-primary" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-primary-text">Easy deposit in 3 steps</p>
+                        <p className="text-xs text-secondary-text leading-snug mt-0.5">
+                            Send from anywhere and receive the asset you want.
+                        </p>
+                    </div>
+                </div>
+                {!isModal && (
+                    <button
+                        type="button"
+                        onClick={() => setShowAllSteps(v => !v)}
+                        aria-expanded={showAllSteps}
+                        className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-primary hover:text-primary/80 transition-colors"
+                    >
+                        <span>{showAllSteps ? "Hide steps" : "See how it works"}</span>
+                        <ChevronDown
+                            className={clsx("h-3.5 w-3.5 transition-transform duration-200", showAllSteps && "rotate-180")}
+                            aria-hidden="true"
+                        />
+                    </button>
+                )}
+            </div>
+
+            <AnimatePresence initial={false}>
+                {stepsVisible && (
+                    <motion.div
+                        key="steps"
+                        initial={isModal ? false : { height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: "easeInOut" }}
+                        style={{ overflow: "hidden" }}
+                    >
+                        <div className="mx-3.5 border-t-2 border-dashed border-secondary-300" />
+                        <div className="relative">
+                            <motion.ol
+                                className="px-3.5 pb-3.5 pt-4"
+                                initial={false}
+                                animate={{ maxHeight: peek ? 128 : 600 }}
+                                transition={{ duration: 0.25, ease: "easeInOut" }}
+                                style={{ overflow: "hidden", maxHeight: peek ? 128 : 600 }}
+                            >
+                                {STEPS.map((step, index) => {
+                                    const isLast = index === STEPS.length - 1;
+                                    const isCurrent = currentStepIndex === index;
+                                    return (
+                                        <li key={step.title} className={clsx("relative", !isLast && "pb-6")}>
+                                            {!isLast && (
+                                                <span
+                                                    aria-hidden="true"
+                                                    className="absolute top-8 left-4 -ml-px h-[calc(100%-2rem)] w-0.5 bg-primary/20"
+                                                />
+                                            )}
+                                            <div className="flex items-start gap-3">
+                                                <span className="relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/20">
+                                                    <step.Icon className="h-4 w-4 text-primary" strokeWidth={2} aria-hidden="true" />
+                                                </span>
+                                                <div className="min-w-0 flex-1 pt-1">
+                                                    <p className={clsx("text-sm font-medium", isCurrent ? "text-primary" : "text-primary-text")}>{step.title}</p>
+                                                    <p className="text-xs text-secondary-text leading-snug mt-0.5">
+                                                        {step.description}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </li>
+                                    );
+                                })}
+                            </motion.ol>
+                            <AnimatePresence>
+                                {peek && (
+                                    <motion.div
+                                        key="peek-fade"
+                                        initial={{ opacity: 0 }}
+                                        animate={{ opacity: 1 }}
+                                        exit={{ opacity: 0 }}
+                                        transition={{ duration: 0.2 }}
+                                        className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-secondary-500 to-transparent"
+                                    />
+                                )}
+                            </AnimatePresence>
+                        </div>
+                        {isModal && (
+                            <div className="px-3.5 pb-3.5 -mt-1 relative z-10">
+                                <button
+                                    type="button"
+                                    onClick={() => setShowAllSteps(v => !v)}
+                                    aria-expanded={showAllSteps}
+                                    className="inline-flex items-center gap-1 text-xs font-semibold text-primary hover:text-primary/80 transition-colors"
+                                >
+                                    <span>{showAllSteps ? "Show less" : "See all steps"}</span>
+                                    <ChevronDown
+                                        className={clsx("h-3.5 w-3.5 transition-transform duration-200", showAllSteps && "rotate-180")}
+                                        aria-hidden="true"
+                                    />
+                                </button>
+                            </div>
+                        )}
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+};
+
+export default EasyDepositBanner;

--- a/components/WalletModal/index.tsx
+++ b/components/WalletModal/index.tsx
@@ -1,4 +1,4 @@
-import { Context, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { Context, createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { InternalConnector, Wallet, WalletProvider } from '../../Models/WalletProvider';
 
 export type WalletModalConnector = InternalConnector & {
@@ -18,10 +18,10 @@ export type ModalWalletProvider = WalletProvider & {
     isSelectedFromFilter?: boolean;
 }
 
-type SharedType = { provider?: WalletProvider, connectCallback: (value: Wallet | undefined) => void, dismissible?: boolean }
+type SharedType = { provider?: WalletProvider, connectCallback: (value: Wallet | undefined) => void, dismissible?: boolean, topContent?: ReactNode, fullHeight?: boolean, hideHeader?: boolean }
 
 type ConnectModalContextType = {
-    connect: ({ provider, connectCallback, dismissible }: SharedType) => void;
+    connect: ({ provider, connectCallback, dismissible, topContent, fullHeight, hideHeader }: SharedType) => void;
     cancel: () => void;
     selectedProvider: ModalWalletProvider | undefined;
     setSelectedProvider: (value: ModalWalletProvider | undefined) => void;
@@ -35,6 +35,9 @@ type ConnectModalContextType = {
     setOpen: (value: boolean) => void;
     open: boolean;
     dismissible: boolean;
+    topContent: ReactNode;
+    fullHeight: boolean;
+    hideHeader: boolean;
 };
 
 const ConnectModalContext = createContext<ConnectModalContextType | null>(null);
@@ -48,8 +51,11 @@ export function WalletModalProvider({ children }) {
     const [open, setOpen] = useState(false);
     const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
     const [dismissible, setDismissible] = useState(true);
+    const [topContent, setTopContent] = useState<ReactNode>(null);
+    const [fullHeight, setFullHeight] = useState(false);
+    const [hideHeader, setHideHeader] = useState(false);
 
-    const connect = useCallback(async ({ provider, connectCallback, dismissible: dismissibleArg = true }: SharedType) => {
+    const connect = useCallback(async ({ provider, connectCallback, dismissible: dismissibleArg = true, topContent: topContentArg = null, fullHeight: fullHeightArg = false, hideHeader: hideHeaderArg = false }: SharedType) => {
         const hasConnectorPicker = !!provider?.availableConnectors?.length
             || !!provider?.additionalConnectors?.length
             || !!provider?.requestAdditionalConnectors
@@ -59,8 +65,11 @@ export function WalletModalProvider({ children }) {
         }
         setSelectedProvider(provider);
         setDismissible(dismissibleArg);
+        setTopContent(topContentArg);
+        setFullHeight(fullHeightArg);
+        setHideHeader(hideHeaderArg);
         setOpen(true)
-        setConnectConfig({ provider, connectCallback, dismissible: dismissibleArg });
+        setConnectConfig({ provider, connectCallback, dismissible: dismissibleArg, topContent: topContentArg, fullHeight: fullHeightArg, hideHeader: hideHeaderArg });
         return;
     }, [])
 
@@ -97,7 +106,12 @@ export function WalletModalProvider({ children }) {
             setSelectedMultiChainConnector(undefined)
             setSelectedProvider(undefined)
         }
-        if (!open) setDismissible(true)
+        if (!open) {
+            setDismissible(true)
+            setTopContent(null)
+            setFullHeight(false)
+            setHideHeader(false)
+        }
         setIsWalletModalOpen(open)
     }, [open])
 
@@ -105,9 +119,9 @@ export function WalletModalProvider({ children }) {
         connect, cancel, selectedProvider, setSelectedProvider,
         selectedConnector, setSelectedConnector,
         selectedMultiChainConnector, setSelectedMultiChainConnector,
-        isWalletModalOpen, goBack, onFinish, setOpen, open, dismissible
+        isWalletModalOpen, goBack, onFinish, setOpen, open, dismissible, topContent, fullHeight, hideHeader
     }), [connect, cancel, selectedProvider, selectedConnector,
-        selectedMultiChainConnector, isWalletModalOpen, goBack, onFinish, open, dismissible])
+        selectedMultiChainConnector, isWalletModalOpen, goBack, onFinish, open, dismissible, topContent, fullHeight, hideHeader])
 
     return (
         <ConnectModalContext.Provider value={contextValue}>
@@ -125,9 +139,9 @@ export const useConnectModal = () => {
     }
 
     const connect = useCallback(
-        (provider?: WalletProvider, options?: { dismissible?: boolean }): Promise<Wallet | undefined> =>
+        (provider?: WalletProvider, options?: { dismissible?: boolean, topContent?: ReactNode, fullHeight?: boolean, hideHeader?: boolean }): Promise<Wallet | undefined> =>
             new Promise((res) => {
-                context.connect({ provider, connectCallback: res, dismissible: options?.dismissible });
+                context.connect({ provider, connectCallback: res, dismissible: options?.dismissible, topContent: options?.topContent, fullHeight: options?.fullHeight, hideHeader: options?.hideHeader });
             }),
         [context.connect]
     );

--- a/components/modal/vaulModal.tsx
+++ b/components/modal/vaulModal.tsx
@@ -189,21 +189,23 @@ const Comp: FC<VaulDrawerProps> = ({ children, show, setShow, header, descriptio
                             </div>
                         }
 
-                        <div className='flex items-center w-full text-left justify-between px-4 sm:pt-2 pb-2'>
-                            <Drawer.Title className="text-lg text-secondary-text font-semibold w-full">
-                                {header}
-                            </Drawer.Title>
-                            {dismissible && (
-                                <Drawer.Close asChild>
-                                    <div>
-                                        <IconButton className='inline-flex active:animate-press-down' icon={
-                                            <X strokeWidth={3} />
-                                        }>
-                                        </IconButton>
-                                    </div>
-                                </Drawer.Close>
-                            )}
-                        </div>
+                        {(header || dismissible) && (
+                            <div className='flex items-center w-full text-left justify-between px-4 sm:pt-2 pb-2'>
+                                <Drawer.Title className="text-lg text-secondary-text font-semibold w-full">
+                                    {header}
+                                </Drawer.Title>
+                                {dismissible && (
+                                    <Drawer.Close asChild>
+                                        <div>
+                                            <IconButton className='inline-flex active:animate-press-down' icon={
+                                                <X strokeWidth={3} />
+                                            }>
+                                            </IconButton>
+                                        </div>
+                                    </Drawer.Close>
+                                )}
+                            </div>
+                        )}
                         {
                             description &&
                             <Drawer.Description className="text-sm mt-2 text-secondary-text px-4">

--- a/context/walletProviders.tsx
+++ b/context/walletProviders.tsx
@@ -16,6 +16,7 @@ import useBitcoin from "../lib/wallets/bitcoin/useBitcoin";
 import { isMobile } from "@/lib/wallets/connectors/utils/isMobile";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
 import dynamic from "next/dynamic";
+import clsx from "clsx";
 
 const ConnectorsList = dynamic(() => import("../components/WalletModal/ConnectorsList"), {
     ssr: false
@@ -27,7 +28,7 @@ export const WalletProvidersProvider: React.FC<React.PropsWithChildren> = ({ chi
     const { networks } = useSettingsState();
     const isMobilePlatform = isMobile();
     const { isMobile: isMobileSize } = useWindowDimensions()
-    const { goBack, onFinish, open, setOpen, selectedConnector, selectedMultiChainConnector, dismissible } = useConnectModal()
+    const { goBack, onFinish, open, setOpen, selectedConnector, selectedMultiChainConnector, dismissible, topContent, fullHeight, hideHeader } = useConnectModal()
 
     const bitcoin = useBitcoin()
     const evm = useEVM();
@@ -62,7 +63,7 @@ export const WalletProvidersProvider: React.FC<React.PropsWithChildren> = ({ chi
                 onClose={onFinish}
                 modalId={"connectNewWallet"}
                 dismissible={dismissible}
-                header={
+                header={hideHeader ? undefined : (
                     <div className="flex items-center gap-1">
                         {
                             (selectedConnector || selectedMultiChainConnector) &&
@@ -75,9 +76,16 @@ export const WalletProvidersProvider: React.FC<React.PropsWithChildren> = ({ chi
                         }
                         <p>{(selectedMultiChainConnector && !selectedConnector) ? "Select ecosystem" : "Connect wallet"}</p>
                     </div>
-                }>
-                <VaulDrawer.Snap openFullHeight id='item-1' className="h-full max-h-[83svh] sm:max-h-full">
-                    {open ? <ConnectorsList onFinish={onFinish} /> : null}
+                )}>
+                <VaulDrawer.Snap openFullHeight id='item-1' className={clsx("h-full max-h-[83svh] sm:max-h-full", fullHeight && "openpicker", hideHeader && "pt-4")}>
+                    {open ? (
+                        <div className="flex flex-col gap-3 h-full">
+                            {!selectedConnector && !selectedMultiChainConnector ? topContent : null}
+                            <div className="flex-1 min-h-0">
+                                <ConnectorsList onFinish={onFinish} />
+                            </div>
+                        </div>
+                    ) : null}
                 </VaulDrawer.Snap>
             </VaulDrawer>
         </WalletProvidersContext.Provider>


### PR DESCRIPTION
## Summary

- **New `EasyDepositBanner` component** with two variants (`inline` for form mount, `modal` for the auto-opened wallet picker with peek-view + step highlighting).
- **Generic `topContent` / `fullHeight` / `hideHeader` options** on `useConnectModal().connect()` so any caller can mount JSX above the connector list, opt into the full-height widget, and suppress the modal header. All flags default off — existing callers are unaffected.
- **Deposit-address card redesigned**: single `bg-secondary-400` background, QR flush against the left edge of the card, address in the right cell with dynamic `maxWidth: ${Math.ceil(length / 3) + 2}ch` enforcing min 3 lines and staying responsive. End 4 chars + copy icon kept together via `whitespace-nowrap`. Font bumped to `text-lg`.
- **Fee/Min-Max split** into two separate containers. The Fees container shows the "for larger sends" tier stacked on the right of the main fee with a chevron toggle. Est. time row removed.
- `vaulModal` no longer renders an empty header bar when there's neither a header nor a dismissible X.

## Test plan

- [x] Open Easy deposit tab with no wallet connected → wallet picker auto-opens with the "Easy deposit in 3 steps" banner at the top, header hidden, modal at full height.
- [x] Pick a wallet → banner disappears; LoadingConnect view shows; back arrow restores list + banner.
- [x] Connect wallet → modal closes; inline banner is visible at the top of the form with collapsed "See how it works" toggle.
- [x] Click "See how it works" → 3 steps animate open.
- [x] Deposit-address card: address wraps to 3 lines for both Ethereum (42-char) and Solana (44-char) addresses; copy icon stays inline with the last 4 chars; QR flush left; centered between QR and card right edge.
- [x] Min/Max + Fees split into two cards with spacing.
- [x] Multi-tier route → "for larger sends" sub-row visible; chevron expands to full tier breakdown.
- [x] Other callers of `connect()` (Source picker, Address picker, withdraw flows) still see the normal-sized modal with the "Connect wallet" header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)