### PR TITLE
Consolidate three families of duplicated helper logic that had drifted across the codebase, and fix one latent bug along the way.

### DIFF
--- a/components/Common/AverageCompletionTime.tsx
+++ b/components/Common/AverageCompletionTime.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+import { formatVerboseHms, parseHmsString } from "@/components/utils/formatTime";
 
 type AverageCompletionTimeProps = {
     avgCompletionTime: string | undefined
@@ -6,15 +7,10 @@ type AverageCompletionTimeProps = {
 }
 
 const AverageCompletionTime: FC<AverageCompletionTimeProps> = ({ avgCompletionTime, className }) => {
+    const parts = parseHmsString(avgCompletionTime);
+    if (!parts) return;
 
-    if (!avgCompletionTime) return
-
-    const time = avgCompletionTime?.split(':');
-    const hours = Number(time[0])
-    const minutes = Number(time[1])
-    const seconds = Number(time[2])
-
-    return <p className={className}><span>{hours > 0 ? `${hours.toFixed()} ${(hours > 1 ? 'hours' : 'hour')}` : ''}</span> <span>{minutes > 0 ? `${minutes.toFixed()} ${(minutes > 1 ? 'minutes' : 'minute')}` : ''}</span> <span>{(seconds > 0 && minutes == 0 && hours == 0) ? `${seconds.toFixed()} secs` : ''}</span></p>
+    return <p className={className}>{formatVerboseHms(parts)}</p>
 }
 
 export default AverageCompletionTime

--- a/components/Common/CountDownTimer.tsx
+++ b/components/Common/CountDownTimer.tsx
@@ -1,6 +1,7 @@
 import { FC, useEffect, useState } from "react";
 import { SwapStatus } from "@/Models/SwapStatus";
 import { SwapDetails, TransactionType } from "@/lib/apiClients/layerSwapApiClient";
+import { formatHmsClock, msToParts } from "@/components/utils/formatTime";
 
 const CountdownTimer: FC<{ initialTime: string, swapDetails: SwapDetails, onThresholdChange?: (threshold: boolean) => void }> = ({ initialTime, swapDetails, onThresholdChange }) => {
     const [elapsedTimer, setElapsedTimer] = useState<number>(0);
@@ -27,18 +28,7 @@ const CountdownTimer: FC<{ initialTime: string, swapDetails: SwapDetails, onThre
         return () => clearInterval(timer);
     }, [initialTime, swapDetails.status, swapInputTransaction?.timestamp]);
 
-    const formatTime = (milliseconds: number): string => {
-        const totalSeconds = Math.floor(milliseconds / 1000);
-        const hours = Math.floor(totalSeconds / 3600);
-        const minutes = Math.floor((totalSeconds % 3600) / 60);
-        const seconds = totalSeconds % 60;
-        const formattedHours = hours > 0 ? String(hours).padStart(2, '0') + ":" : ''
-        const formattedMinutes = String(minutes).padStart(2, '0')
-        const formattedSeconds = String(seconds).padStart(2, '0')
-
-        return `${formattedHours}${formattedMinutes}:${formattedSeconds}`;
-    };
-    const formatted = formatTime(elapsedTimer);
+    const formatted = formatHmsClock(msToParts(elapsedTimer));
 
     if (swapDetails.status === SwapStatus.Completed) return null;
 
@@ -64,7 +54,7 @@ const CountdownTimer: FC<{ initialTime: string, swapDetails: SwapDetails, onThre
 
 export default CountdownTimer;
 
-function timeStringToMilliseconds(timeString) {
+function timeStringToMilliseconds(timeString: string) {
     const parts = timeString.split('.');
     const time = parts[0];
     const [hours, minutes, seconds] = time.split(':').map(parseFloat);

--- a/components/Common/FormattedAverageCompletionTime.tsx
+++ b/components/Common/FormattedAverageCompletionTime.tsx
@@ -1,25 +1,15 @@
 import { FC } from "react";
+import { formatHmsClock, parseHmsString } from "@/components/utils/formatTime";
 
 type AverageCompletionTimeProps = {
     avgCompletionTime: string | undefined
 }
 
 const FormattedAverageCompletionTime: FC<AverageCompletionTimeProps> = ({ avgCompletionTime }) => {
+    const parts = parseHmsString(avgCompletionTime);
+    if (!parts) return;
 
-    if (!avgCompletionTime) return
-
-    const parts = avgCompletionTime.split('.');
-    const time = parts[0];
-    const [hours, minutes, seconds] = time.split(':').map(parseFloat);
-    
-    const formattedHours = hours>0 ? String(hours).padStart(2, '0') + ":" : ''
-    const formattedMinutes = String(minutes).padStart(2, '0')
-    const formattedSeconds = String(seconds).padStart(2, '0')
-
-    const fullFormatted = `${formattedHours}${formattedMinutes}:${formattedSeconds}`;
-    return <span>
-        {fullFormatted}
-    </span>
+    return <span>{formatHmsClock(parts)}</span>
 }
 
 export default FormattedAverageCompletionTime

--- a/components/Input/Amount/index.tsx
+++ b/components/Input/Amount/index.tsx
@@ -4,6 +4,7 @@ import { SwapFormValues } from "@/components/DTOs/SwapFormValues";
 import NumericInput from "../NumericInput";
 import { QuoteTokenPrices, useQuoteData } from "@/hooks/useFee";
 import { formatUsd } from "@/components/utils/formatUsdAmount";
+import { truncateDecimals } from "@/components/utils/RoundDecimals";
 import clsx from "clsx";
 import { useUsdTokenSync } from "@/hooks/useUsdTokenSync";
 import { ArrowUpDown } from "lucide-react";
@@ -69,14 +70,14 @@ const AmountField = forwardRef(function AmountField({ actionValue, actionValueUs
     const actionValueAsToken = useMemo(() => {
         if (actionValue === undefined || actionValue <= 0) return undefined;
         const precision = fromCurrency?.precision || 6;
-        return formatTokenAmount(actionValue, precision);
+        return truncateDecimals(actionValue, precision);
     }, [actionValue, fromCurrency?.precision]);
 
     const formattedTokenAmount = useMemo(() => {
         const num = Number(amount);
         if (isNaN(num) || num <= 0) return '0';
         const precision = fromCurrency?.precision || 6;
-        return formatTokenAmount(num, precision);
+        return truncateDecimals(num, precision);
     }, [amount, fromCurrency?.precision]);
 
     // --- Suffix positioning for token mode ---
@@ -200,9 +201,3 @@ function getFontFromElement(el: HTMLElement | null): string {
     return `${style.fontSize} ${style.fontFamily}`;
 }
 
-function formatTokenAmount(value: number, precision: number): string {
-    const fixed = value.toFixed(precision).replace(/\.?0+$/, '');
-    const [intPart, decPart] = fixed.split('.');
-    const formattedInt = Number(intPart).toLocaleString('en-US');
-    return decPart ? `${formattedInt}.${decPart}` : formattedInt;
-}

--- a/components/Swap/Form/DepositAddressForm/DepositAddressInfo.tsx
+++ b/components/Swap/Form/DepositAddressForm/DepositAddressInfo.tsx
@@ -4,7 +4,9 @@ import { QRCodeSVG } from "qrcode.react";
 import { AnimatePresence, motion } from "framer-motion";
 import useCopyClipboard from "@/hooks/useCopyClipboard";
 import { useDetailedQuote } from "@/hooks/useDetailedQuote";
-import { formatCompletionTime, formatFee, formatTierRange, formatTokenAmount } from "./helpers";
+import { formatFee, formatTierRange } from "./helpers";
+import { formatTokenAmount } from "@/components/utils/formatTokenAmount";
+import { formatEtaFromMs } from "@/components/utils/formatTime";
 
 type DepositAddressInfoProps = {
     sourceNetwork: string | undefined;
@@ -211,7 +213,7 @@ const DepositAddressInfo: FC<DepositAddressInfoProps> = ({
                                             <span className="flex items-center gap-3">
                                                 <span className="text-primary-text">{fee}</span>
                                                 <span className="tabular-nums min-w-14 text-right text-secondary-text/80">
-                                                    {formatCompletionTime(tier.avg_completion_milliseconds)}
+                                                    {formatEtaFromMs(tier.avg_completion_milliseconds)}
                                                 </span>
                                             </span>
                                         </div>

--- a/components/Swap/Form/DepositAddressForm/helpers.ts
+++ b/components/Swap/Form/DepositAddressForm/helpers.ts
@@ -1,16 +1,7 @@
-import { DepositAction } from "@/lib/apiClients/layerSwapApiClient";
 import { DetailedQuoteModel } from "@/hooks/useDetailedQuote";
 import { formatPercent } from "@/components/utils/formatPercent";
 import { formatUsd } from "@/components/utils/formatUsdAmount";
-
-export function formatCompletionTime(ms: number): string {
-    const seconds = Math.floor(ms / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    if (hours > 0) return `~${hours}h`;
-    if (minutes > 0) return `~${minutes} min`;
-    return `~${seconds}s`;
-}
+import { formatTokenAmount } from "@/components/utils/formatTokenAmount";
 
 export function formatFee(percentageFee: number, fixedFeeUsd: number): string {
     const parts: string[] = [];
@@ -20,31 +11,10 @@ export function formatFee(percentageFee: number, fixedFeeUsd: number): string {
     return parts.join(' + ') || 'Free';
 }
 
-export function formatTokenAmount(value: number): string {
-    if (!Number.isFinite(value)) return '';
-    if (value === 0) return '0';
-    let maximumFractionDigits: number;
-    if (value >= 1000) maximumFractionDigits = 0;
-    else if (value >= 10) maximumFractionDigits = 2;
-    else if (value >= 1) maximumFractionDigits = 4;
-    else maximumFractionDigits = 6;
-    return value.toLocaleString('en-US', { maximumFractionDigits });
-}
-
 export function formatTierRange(tier: DetailedQuoteModel, isFirst: boolean, isLast: boolean, symbol: string): string {
     const min = formatTokenAmount(tier.min_amount);
     const max = formatTokenAmount(tier.max_amount);
     if (isFirst) return `Up to ${max} ${symbol}`;
     if (isLast) return `Over ${min} ${symbol}`;
     return `${min} – ${max} ${symbol}`;
-}
-
-export function resolveDepositAddress(
-    network: { type?: string } | undefined,
-    depositActions: DepositAction[] | undefined
-): string | undefined {
-    if (!depositActions || depositActions.length === 0) return undefined;
-    if (!network) return depositActions[0].to_address;
-    const match = depositActions.find(a => a.network?.type === network.type);
-    return match?.to_address ?? depositActions[0].to_address;
 }

--- a/components/Swap/Form/DepositAddressForm/index.tsx
+++ b/components/Swap/Form/DepositAddressForm/index.tsx
@@ -23,7 +23,7 @@ import PayFromPicker from "./PayFromPicker";
 import ReceivePicker from "./ReceivePicker";
 import DepositAddressInfo from "./DepositAddressInfo";
 import DepositAddressFormButton from "./DepositAddressFormButton";
-import { resolveDepositAddress } from "./helpers";
+import { resolveDepositAddress } from "@/helpers/depositActions";
 
 type Props = {
     partner?: Partner;

--- a/components/Swap/Withdraw/ManualWithdraw.tsx
+++ b/components/Swap/Withdraw/ManualWithdraw.tsx
@@ -22,6 +22,7 @@ import { handleLimitsUpdate } from './QuoteUpdate'
 import SubmitButton from '@/components/buttons/submitButton'
 import { Widget } from '@/components/Widget/Index'
 import { truncateDecimals } from '@/components/utils/RoundDecimals'
+import { resolveDepositAddress } from '@/helpers/depositActions'
 import { Partner } from '@/Models/Partner'
 import { ExtendedAddress } from '@/components/Input/Address/AddressPicker/AddressWithIcon'
 import QuoteDetails from '@/components/FeeDetails'
@@ -55,7 +56,7 @@ const ManualWithdraw: FC<Props> = ({ swapBasicData, depositActions, refuel, part
     const destinationLogo = swapBasicData?.destination_network?.logo
     const [copied, copy] = useCopyClipboard()
     const query = useQueryState()
-    const depositAddress = depositActions?.find(da => true)?.to_address;
+    const depositAddress = resolveDepositAddress(swapBasicData?.source_network, depositActions);
     const { destination_address: destinationAddressFromQuery } = query
 
     const WalletIcon = wallets.find(wallet => wallet.address.toLowerCase() == swapBasicData?.destination_address?.toLowerCase())?.icon;

--- a/components/SwapHistory/HistorySummary.tsx
+++ b/components/SwapHistory/HistorySummary.tsx
@@ -107,7 +107,7 @@ const HistorySummary: FC<SwapInfoProps> = ({
                                 <Tooltip>
                                     <TooltipTrigger asChild>
                                         <span className="truncate block shrink">
-                                            {receiveAmount.toLocaleString('en-US', { maximumFractionDigits: 20 })}
+                                            {truncateDecimals(receiveAmount, destination_token.precision)}
                                         </span>
                                     </TooltipTrigger>
                                     <TooltipContent>

--- a/components/utils/formatTime.ts
+++ b/components/utils/formatTime.ts
@@ -1,0 +1,55 @@
+export type TimeParts = { hours: number; minutes: number; seconds: number };
+
+export function msToParts(ms: number): TimeParts {
+    const totalSeconds = Math.floor(ms / 1000);
+    return {
+        hours: Math.floor(totalSeconds / 3600),
+        minutes: Math.floor((totalSeconds % 3600) / 60),
+        seconds: totalSeconds % 60,
+    };
+}
+
+/** Parse "H:MM:SS" or "H:MM:SS.fff" (API average completion format). */
+export function parseHmsString(value: string | undefined): TimeParts | null {
+    if (!value) return null;
+    const [whole] = value.split('.');
+    const segments = whole.split(':').map(Number);
+    if (segments.length !== 3 || segments.some(n => Number.isNaN(n))) return null;
+    const [hours, minutes, seconds] = segments;
+    return { hours, minutes, seconds };
+}
+
+/** ETA-style: "~3h" | "~12 min" | "~45s" — highest non-zero unit only. */
+export function formatEtaFromMs(ms: number): string {
+    const { hours, minutes, seconds } = msToParts(ms);
+    if (hours > 0) return `~${hours}h`;
+    if (minutes > 0) return `~${minutes} min`;
+    return `~${seconds}s`;
+}
+
+/** Digital-clock format: "01:23:45" (hours omitted when zero). */
+export function formatHmsClock(parts: TimeParts): string {
+    const h = parts.hours > 0 ? String(parts.hours).padStart(2, '0') + ':' : '';
+    const m = String(parts.minutes).padStart(2, '0');
+    const s = String(parts.seconds).padStart(2, '0');
+    return `${h}${m}:${s}`;
+}
+
+/** Verbose elapsed: "1h 23m 45s" — drops zero leading units. */
+export function formatElapsedHms(parts: TimeParts): string {
+    const out: string[] = [];
+    if (parts.hours) out.push(`${parts.hours}h`);
+    if (parts.minutes) out.push(`${parts.minutes}m`);
+    if (!parts.hours && (parts.seconds || !parts.minutes)) out.push(`${parts.seconds}s`);
+    return out.join(' ');
+}
+
+/** Pluralized words: "1 hour 23 minutes" / "45 secs". */
+export function formatVerboseHms(parts: TimeParts): string {
+    const { hours, minutes, seconds } = parts;
+    const segments: string[] = [];
+    if (hours > 0) segments.push(`${hours} ${hours > 1 ? 'hours' : 'hour'}`);
+    if (minutes > 0) segments.push(`${minutes} ${minutes > 1 ? 'minutes' : 'minute'}`);
+    if (seconds > 0 && minutes === 0 && hours === 0) segments.push(`${seconds} secs`);
+    return segments.join(' ');
+}

--- a/components/utils/formatTokenAmount.ts
+++ b/components/utils/formatTokenAmount.ts
@@ -1,0 +1,14 @@
+/** Format a token amount without a known token precision.
+ *  Picks decimals adaptively based on magnitude — useful for tier/range
+ *  displays where the source token's precision isn't in scope.
+ *  When you do have `token.precision`, prefer `truncateDecimals` from RoundDecimals.ts. */
+export function formatTokenAmount(value: number): string {
+    if (!Number.isFinite(value)) return '';
+    if (value === 0) return '0';
+    let maximumFractionDigits: number;
+    if (value >= 1000) maximumFractionDigits = 0;
+    else if (value >= 10) maximumFractionDigits = 2;
+    else if (value >= 1) maximumFractionDigits = 4;
+    else maximumFractionDigits = 6;
+    return value.toLocaleString('en-US', { maximumFractionDigits });
+}

--- a/components/utils/resolveSwapPhase.ts
+++ b/components/utils/resolveSwapPhase.ts
@@ -10,6 +10,7 @@ import { SwapStatus } from '../../Models/SwapStatus';
 import { SwapFailReasons } from '../../Models/RangeError';
 import { Progress, ProgressStatus } from '../Swap/Withdraw/Processing/types';
 import type { SwapTransaction as StoredWalletTransaction } from '../../stores/swapTransactionStore';
+import { formatElapsedHms, msToParts } from './formatTime';
 
 export enum SwapPhase {
     AwaitingUserDeposit = 'awaiting_user_deposit',
@@ -341,15 +342,5 @@ function formatElapsedTime(inputTx: Transaction | undefined, outputTx: Transacti
     const diffMs = new Date(end).getTime() - new Date(start).getTime();
     if (!Number.isFinite(diffMs) || diffMs <= 0) return null;
 
-    const totalSeconds = Math.round(diffMs / 1000);
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-
-    const parts: string[] = [];
-    if (hours) parts.push(`${hours}h`);
-    if (minutes) parts.push(`${minutes}m`);
-    if (!hours && (seconds || !minutes)) parts.push(`${seconds}s`);
-
-    return `Completed in ${parts.join(' ')}`;
+    return `Completed in ${formatElapsedHms(msToParts(diffMs))}`;
 }

--- a/helpers/depositActions.ts
+++ b/helpers/depositActions.ts
@@ -1,0 +1,11 @@
+import { DepositAction } from "@/lib/apiClients/layerSwapApiClient";
+
+export function resolveDepositAddress(
+    network: { type?: string } | undefined,
+    depositActions: DepositAction[] | undefined
+): string | undefined {
+    if (!depositActions || depositActions.length === 0) return undefined;
+    if (!network) return depositActions[0].to_address;
+    const match = depositActions.find(a => a.network?.type === network.type);
+    return match?.to_address ?? depositActions[0].to_address;
+}


### PR DESCRIPTION
- **`resolveDepositAddress`** — extracted to `helpers/depositActions.ts`. `ManualWithdraw.tsx` previously did `depositActions?.find(da =>
  true)?.to_address` which silently ignored network type and could pick the wrong action when a swap has multiple deposit actions. It now uses the shared
  helper with `swapBasicData?.source_network`.
  - **Token-amount formatting** — three competing implementations collapsed:
    - Magnitude-based variant moved to `components/utils/formatTokenAmount.ts` (used when token precision isn't in scope, e.g. tier displays).
    - Local precision-based copy in `Input/Amount/index.tsx` deleted; the two call sites now use the project-wide `truncateDecimals` (already used in 40+
  places).
    - Inline `toLocaleString('en-US', { maximumFractionDigits: 20 })` in `SwapHistory/HistorySummary.tsx:110` replaced with
  `truncateDecimals(receiveAmount, destination_token.precision)` to match the sibling sent-amount line.
  - **Time formatting** — five overlapping ms / HMS-string formatters now share `components/utils/formatTime.ts`:
    - Primitives: `msToParts`, `parseHmsString`.
    - Outputs: `formatEtaFromMs` (`~3h`/`~12 min`/`~45s`), `formatHmsClock` (`01:23:45`), `formatElapsedHms` (`1h 23m 45s`), `formatVerboseHms` (`1 hour 23
   minutes`).
    - Refactored: `DepositAddressForm/helpers.ts`, `utils/resolveSwapPhase.ts`, `Common/CountDownTimer.tsx`, `Common/AverageCompletionTime.tsx`,
  `Common/FormattedAverageCompletionTime.tsx`.

  No behavior changes intended except the `ManualWithdraw` deposit-address fix.