### PR TITLE
refactor: inline add/edit in Address Book

### DIFF
--- a/components/AddressBook/AddressBookEntryForm.tsx
+++ b/components/AddressBook/AddressBookEntryForm.tsx
@@ -1,5 +1,6 @@
-import { FC, ReactNode, useState } from 'react'
+import { FC, useState } from 'react'
 import clsx from 'clsx'
+import { X } from 'lucide-react'
 import { useAddressBookStore, NAME_MAX, COUNTER_SHOW_AT } from '@/stores/addressBookStore'
 import { NetworkType } from '@/Models/Network'
 
@@ -36,54 +37,59 @@ const AddressBookEntryForm: FC<AddressBookEntryFormProps> = ({ initial, onClose 
         onClose()
     }
 
+    const onKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    }
+
     return (
-        <form onSubmit={submit} className="flex flex-col h-full">
-            <div className="flex flex-col gap-2">
-                <Field
-                    label="Name"
-                    hint={trimmedName.length > COUNTER_SHOW_AT && (
-                        <span className={clsx('text-xs tabular-nums', trimmedName.length > NAME_MAX ? 'text-error-foreground' : 'text-secondary-text')}>
+        <form onSubmit={submit} onKeyDown={onKeyDown} className="flex items-start gap-2 min-w-0 w-full">
+            <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+                <div className="relative w-full">
+                    <input
+                        type="text"
+                        autoFocus
+                        value={name}
+                        onChange={e => setName(e.target.value)}
+                        placeholder="Name this address"
+                        autoComplete="off"
+                        className="w-full h-9 pl-3 pr-14 rounded-lg text-sm bg-secondary-300 border border-transparent text-primary-text placeholder:text-secondary-text focus:border-primary focus:ring-0 focus:outline-hidden"
+                    />
+                    {trimmedName.length > COUNTER_SHOW_AT && (
+                        <span className={clsx('absolute right-3 top-1/2 -translate-y-1/2 text-xs tabular-nums', trimmedName.length > NAME_MAX ? 'text-error-foreground' : 'text-secondary-text')}>
                             {trimmedName.length} / {NAME_MAX}
                         </span>
                     )}
-                >
-                    <input
-                        type="text"
-                        value={name}
-                        onChange={e => setName(e.target.value)}
-                        placeholder="My Layerswap wallet…"
-                        autoComplete="off"
-                        className="w-full h-14 bg-transparent border-0 outline-none text-primary-text placeholder:text-secondary-text text-[22px] font-normal leading-7 focus:ring-0 p-0"
-                    />
-                </Field>
-                <Field label="Address">
-                    <input
-                        type="text"
-                        value={address}
-                        onChange={e => setAddress(e.target.value.replace(/\s+/g, ''))}
-                        placeholder="0x…"
-                        autoCorrect="off"
-                        autoComplete="off"
-                        spellCheck={false}
-                        className="w-full h-14 bg-transparent border-0 outline-none text-primary-text placeholder:text-secondary-text text-[22px] leading-7 focus:ring-0 p-0"
-                    />
-                </Field>
+                </div>
+                <input
+                    type="text"
+                    value={address}
+                    onChange={e => setAddress(e.target.value.replace(/\s+/g, ''))}
+                    placeholder="0x…"
+                    autoCorrect="off"
+                    autoComplete="off"
+                    spellCheck={false}
+                    className="w-full h-9 px-3 rounded-lg text-sm bg-secondary-300 border border-transparent text-primary-text placeholder:text-secondary-text focus:border-primary focus:ring-0 focus:outline-hidden truncate"
+                />
             </div>
-            <button type="submit" disabled={!canSubmit} className="mt-2 w-full h-12 rounded-xl text-base font-medium bg-primary text-primary-buttonTextColor hover:brightness-110 disabled:bg-secondary-300 disabled:text-secondary-text disabled:cursor-not-allowed transition">
-                Save
-            </button>
+            <div className="flex items-center gap-1.5 shrink-0">
+                <button
+                    type="submit"
+                    disabled={!canSubmit}
+                    className="h-9 px-3 rounded-lg text-sm font-medium bg-primary text-primary-buttonTextColor hover:brightness-110 disabled:bg-secondary-300 disabled:text-secondary-text disabled:cursor-not-allowed transition"
+                >
+                    Save
+                </button>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Cancel"
+                    className="h-9 w-9 flex items-center justify-center rounded-lg text-secondary-text hover:text-primary-text hover:bg-secondary-400 transition"
+                >
+                    <X className="h-4 w-4" />
+                </button>
+            </div>
         </form>
     )
 }
-
-const Field: FC<{ label: string, hint?: ReactNode, children: ReactNode }> = ({ label, hint, children }) => (
-    <label className="block bg-secondary-500 rounded-2xl p-4">
-        <div className="flex items-center justify-between mb-1">
-            <span className="text-secondary-text text-base">{label}</span>
-            {hint}
-        </div>
-        {children}
-    </label>
-)
 
 export default AddressBookEntryForm

--- a/components/AddressBook/AddressBookStep.tsx
+++ b/components/AddressBook/AddressBookStep.tsx
@@ -1,27 +1,27 @@
 import { FC, useMemo, useState } from 'react'
-import { useAddressBookStore, SavedAddress } from '@/stores/addressBookStore'
+import { useAddressBookStore } from '@/stores/addressBookStore'
 import { MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react'
 import AddressIcon from '@/components/AddressIcon'
 import shortenString from '@/components/utils/ShortenString'
 import { ExtendedAddress } from '@/components/Input/Address/AddressPicker/AddressWithIcon'
-import AddressBookEntryForm, { AddressBookEntryFormProps } from './AddressBookEntryForm'
+import AddressBookEntryForm from './AddressBookEntryForm'
 import { HistoryItemSceleton } from '@/components/SwapHistory/Snippet'
 import { SearchComponent } from '@/components/Input/Search'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/shadcn/popover'
 
-type EditingState =
-    | { kind: 'closed' }
-    | { kind: 'create', initial?: AddressBookEntryFormProps['initial'] }
-    | { kind: 'edit', entry: SavedAddress }
+type Inline =
+    | { kind: 'none' }
+    | { kind: 'add' }
+    | { kind: 'edit', address: string }
 
 const AddressBookStep: FC = () => {
     const savedAddresses = useAddressBookStore(s => s.savedAddresses)
     const removeAddress = useAddressBookStore(s => s.removeAddress)
 
-    const [editing, setEditing] = useState<EditingState>({ kind: 'closed' })
+    const [inline, setInline] = useState<Inline>({ kind: 'none' })
     const [query, setQuery] = useState('')
 
-    const closeForm = () => setEditing({ kind: 'closed' })
+    const closeForm = () => setInline({ kind: 'none' })
 
     const filteredAddresses = useMemo(() => {
         const lower = query.trim().toLowerCase()
@@ -33,23 +33,7 @@ const AddressBookStep: FC = () => {
         )
     }, [savedAddresses, query])
 
-    if (editing.kind === 'create') {
-        return <AddressBookEntryForm initial={editing.initial} onClose={closeForm} />
-    }
-    if (editing.kind === 'edit') {
-        return (
-            <AddressBookEntryForm
-                initial={{
-                    name: editing.entry.name,
-                    address: editing.entry.address,
-                    editingOriginalAddress: editing.entry.address,
-                    networkType: editing.entry.networkType,
-                }}
-                onClose={closeForm}
-            />
-        )
-    }
-    if (savedAddresses.length === 0) {
+    if (savedAddresses.length === 0 && inline.kind !== 'add') {
         return (
             <div className="flex flex-col justify-center items-center h-full text-primary-text">
                 <HistoryItemSceleton className="scale-[.63] w-full shadow-card mr-7" />
@@ -58,7 +42,7 @@ const AddressBookStep: FC = () => {
                     <h1 className="text-secondary-text text-[28px] font-bold tracking-wide">No saved addresses</h1>
                     <p className="max-w-xs text-center text-primary-text-tertiary text-base font-normal mx-auto">Label a wallet so its name shows up across the app.</p>
                 </div>
-                <button type="button" onClick={() => setEditing({ kind: 'create' })} className="mt-10 flex items-center gap-2 text-base text-secondary-text font-normal bg-secondary-500 hover:bg-secondary-400 py-2 px-3 rounded-lg">
+                <button type="button" onClick={() => setInline({ kind: 'add' })} className="mt-10 flex items-center gap-2 text-base text-secondary-text font-normal bg-secondary-500 hover:bg-secondary-400 py-2 px-3 rounded-lg">
                     <Plus className="w-4 h-4" />
                     <p>Add address</p>
                 </button>
@@ -75,7 +59,7 @@ const AddressBookStep: FC = () => {
                 containerClassName="mb-2"
             />
             <div className="flex flex-col gap-2">
-                {filteredAddresses.length === 0 && (
+                {filteredAddresses.length === 0 && inline.kind !== 'add' && (
                     <div className="flex items-baseline gap-1 px-1 py-3 text-sm text-secondary-text min-w-0">
                         <span className="shrink-0">No addresses match</span>
                         <span className="truncate min-w-0">&quot;{query}&quot;</span>
@@ -83,58 +67,80 @@ const AddressBookStep: FC = () => {
                 )}
                 {filteredAddresses.map(entry => {
                     const raw = entry.address
+                    const isEditing = inline.kind === 'edit' && inline.address === raw
                     return (
                         <div key={raw} className="flex items-center justify-between gap-2 p-3 rounded-xl bg-secondary-500">
-                            <div className="flex items-center gap-3 min-w-0">
-                                <div className="rounded-md h-8 w-8 overflow-hidden">
-                                    <AddressIcon className="h-8 w-8" address={raw} size={32} rounded="6px" />
-                                </div>
-                                <div className="min-w-0">
-                                    <p className="text-sm font-medium text-primary-text truncate">{entry.name}</p>
-                                    <ExtendedAddress address={raw} providerName={entry.networkType} shouldShowChevron={false}>
-                                        <p className="text-xs text-secondary-text truncate cursor-pointer hover:text-primary-text hover:underline transition w-fit">
-                                            {shortenString(raw)}
-                                        </p>
-                                    </ExtendedAddress>
-                                </div>
-                            </div>
-                            <Popover>
-                                <PopoverTrigger asChild>
-                                    <button type="button" aria-label="More actions" className="p-2 rounded-md hover:bg-secondary-400 text-secondary-text hover:text-primary-text transition">
-                                        <MoreVertical className="h-4 w-4" />
-                                    </button>
-                                </PopoverTrigger>
-                                <PopoverContent align="end" sideOffset={4} className="min-w-[160px] p-1 bg-secondary-500! rounded-xl">
-                                    <button
-                                        type="button"
-                                        onClick={() => setEditing({ kind: 'edit', entry })}
-                                        className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-sm text-primary-text hover:bg-secondary-400 transition"
-                                    >
-                                        <Pencil className="h-4 w-4" />
-                                        <span>Edit</span>
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => removeAddress(raw)}
-                                        className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-sm text-error-foreground hover:bg-secondary-400 transition"
-                                    >
-                                        <Trash2 className="h-4 w-4" />
-                                        <span>Delete</span>
-                                    </button>
-                                </PopoverContent>
-                            </Popover>
+                            {isEditing ? (
+                                <AddressBookEntryForm
+                                    initial={{
+                                        name: entry.name,
+                                        address: entry.address,
+                                        editingOriginalAddress: entry.address,
+                                        networkType: entry.networkType,
+                                    }}
+                                    onClose={closeForm}
+                                />
+                            ) : (
+                                <>
+                                    <div className="flex items-center gap-3 min-w-0">
+                                        <div className="rounded-md h-8 w-8 overflow-hidden">
+                                            <AddressIcon className="h-8 w-8" address={raw} size={32} rounded="6px" />
+                                        </div>
+                                        <div className="min-w-0">
+                                            <p className="text-sm font-medium text-primary-text truncate">{entry.name}</p>
+                                            <ExtendedAddress address={raw} providerName={entry.networkType} shouldShowChevron={false}>
+                                                <p className="text-xs text-secondary-text truncate cursor-pointer hover:text-primary-text hover:underline transition w-fit">
+                                                    {shortenString(raw)}
+                                                </p>
+                                            </ExtendedAddress>
+                                        </div>
+                                    </div>
+                                    <Popover>
+                                        <PopoverTrigger asChild>
+                                            <button type="button" aria-label="More actions" className="p-2 rounded-md hover:bg-secondary-400 text-secondary-text hover:text-primary-text transition">
+                                                <MoreVertical className="h-4 w-4" />
+                                            </button>
+                                        </PopoverTrigger>
+                                        <PopoverContent align="end" sideOffset={4} className="min-w-[160px] p-1 bg-secondary-500! rounded-xl">
+                                            <button
+                                                type="button"
+                                                onClick={() => setInline({ kind: 'edit', address: raw })}
+                                                className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-sm text-primary-text hover:bg-secondary-400 transition"
+                                            >
+                                                <Pencil className="h-4 w-4" />
+                                                <span>Edit</span>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => removeAddress(raw)}
+                                                className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-sm text-error-foreground hover:bg-secondary-400 transition"
+                                            >
+                                                <Trash2 className="h-4 w-4" />
+                                                <span>Delete</span>
+                                            </button>
+                                        </PopoverContent>
+                                    </Popover>
+                                </>
+                            )}
                         </div>
                     )
                 })}
+                {inline.kind === 'add' && (
+                    <div className="p-3 rounded-xl bg-secondary-500">
+                        <AddressBookEntryForm onClose={closeForm} />
+                    </div>
+                )}
             </div>
-            <button
-                type="button"
-                onClick={() => setEditing({ kind: 'create' })}
-                className="mt-2 flex items-center justify-center gap-2 w-full h-12 rounded-xl text-base font-medium bg-secondary-500 hover:bg-secondary-400 text-primary-text transition"
-            >
-                <Plus className="h-5 w-5" />
-                <span>Add address</span>
-            </button>
+            {inline.kind !== 'add' && (
+                <button
+                    type="button"
+                    onClick={() => setInline({ kind: 'add' })}
+                    className="mt-2 flex items-center justify-center gap-2 w-full h-12 rounded-xl text-base font-medium bg-secondary-500 hover:bg-secondary-400 text-primary-text transition"
+                >
+                    <Plus className="h-5 w-5" />
+                    <span>Add address</span>
+                </button>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary

Reworks the Address Book add/edit UX so users stay on the list instead of being thrown to a separate full-screen form.

- **Edit** (3-dot menu → Edit): the chosen row morphs in place into compact Name + Address inputs with Save / X. Rest of the list stays visible.
- **Add address**: expands an inline empty-fields row **under the list**, using the same form.
- Single `Inline` state (`none` / `add` / `edit:address`) — only one form open at a time.
- `Enter` saves, `Escape` / X cancels.

No store changes — `addAddress` / `editAddress` / `removeAddress` reused unchanged; same `NAME_MAX` / `COUNTER_SHOW_AT` validation.

## Files
- `components/AddressBook/AddressBookEntryForm.tsx` — full-screen form → compact inline form.
- `components/AddressBook/AddressBookStep.tsx` — in-place edit + inline add row instead of view-switching.

## Test plan
- [ ] Menu → Address Book → 3-dot → Edit: row turns into inline inputs, list stays visible; Enter/Save persists, Esc/X cancels.
- [ ] Add address: inline row appears under the list; fill + Save adds it; X cancels.
- [ ] Save disabled when Name/Address empty or Name exceeds max (counter turns red).
- [ ] Only one inline form open at a time.
- [ ] Reload persists changes (localStorage `address-book`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)