### PR TITLE
fix: prevent Safari first-open flash on snap-points vaul drawers

### DIFF
--- a/packages/widget/src/components/Modal/vaulModal.tsx
+++ b/packages/widget/src/components/Modal/vaulModal.tsx
@@ -35,12 +35,17 @@ const Comp: FC<VaulDrawerProps> = ({ children, show, setShow, header, descriptio
     const [snap, setSnap] = useState<number | string | null>(null);
     const [snapElement, setSnapElement] = useState<SnapElement | null>(null);
 
-    const { snapPoints } = useSnapPoints()
+    const { snapPoints, snapElemenetsHeight } = useSnapPoints()
     const snapPointsHeight = useMemo(() => snapPoints.map((item) => item.height), [snapPoints]);
 
     const isFitHeightMode = mode === 'fitHeight';
     const isSnapPointsMode = mode === 'snapPoints';
     const isLastSnap = isSnapPointsMode ? snapElement?.id === snapPoints[snapPoints.length - 1]?.id : true;
+
+    const snapPointsSettled = snapElemenetsHeight.length > 0 && snap !== null && snapPointsHeight.includes(snap);
+    const everSettledRef = useRef(false);
+    if (snapPointsSettled) everSettledRef.current = true;
+    const parked = isSnapPointsMode && !everSettledRef.current;
 
     const snapPointsProps = useMemo(() => {
         if (!isSnapPointsMode) return {};
@@ -59,9 +64,9 @@ const Comp: FC<VaulDrawerProps> = ({ children, show, setShow, header, descriptio
     }
 
     useEffect(() => {
-        if (isFitHeightMode || !show || snapPoints.length === 0) return;
+        if (isFitHeightMode || !show || snapPoints.length === 0 || snapElemenetsHeight.length === 0) return;
         setSnapElement(snapPoints.find((item) => item.id === snapElement?.id) || snapPoints[0]);
-    }, [snapPoints, show, mode, snapElement?.id])
+    }, [snapPoints, show, mode, snapElement?.id, snapElemenetsHeight.length])
 
     useEffect(() => {
         if (isFitHeightMode || !snapElement || snapElement.height === snap) return;
@@ -107,7 +112,7 @@ const Comp: FC<VaulDrawerProps> = ({ children, show, setShow, header, descriptio
     }, [mode, show, isMobile])
 
     const handleOpenChange = (open: boolean) => {
-        if (isSnapPointsMode) setSnap(open && snapPoints.length > 0 ? snapPoints[0].height : null);
+        if (isSnapPointsMode) setSnap(open && snapPoints.length > 0 && snapElemenetsHeight.length > 0 ? snapPoints[0].height : null);
         setShow(open);
         if (!open) return onClose && onClose()
     }
@@ -197,6 +202,7 @@ const Comp: FC<VaulDrawerProps> = ({ children, show, setShow, header, descriptio
                 <Drawer.Content
                     data-testid="content"
                     data-fit-height={isFitHeightMode ? 'true' : undefined}
+                    style={parked ? { transform: 'translate3d(0, 100%, 0)', animation: 'none', transition: 'none' } : undefined}
                     className={clsx('absolute bg-secondary-700 rounded-t-3xl bottom-0 left-0 right-0 z-50 text-primary-text ring-0! outline-hidden!', className, {
                         'flex flex-col pb-4 h-full': isSnapPointsMode,
                         'flex flex-col': isFitHeightMode,


### PR DESCRIPTION
  On Safari, the first open of any snap-points drawer (connected wallets,
  source wallet picker) jumped to ~70-80% height, animated back down, then
  played the slide-up — instead of one clean slide from the bottom.

  Before the Snap children are measured, resolveSnapPoints returns a
  placeholder full-height point. vaul snaps to it and writes an inline
  transform animating the drawer to full height; a few frames later the real
  heights land and it retargets back down. Under React 18 (dev branch) this
  cascade flushes before paint so it's never visible; under React 19(monorepo), Safari
  paints the intermediate frames.

  Park Drawer.Content off-screen (translate3d(0,100%,0)) and keep snap null
  until snapElemenetsHeight reports real measurements, so vaul's snapToPoint
  stays inert and can't overwrite the parked transform. A latch ensures we
  unpark once and never re-park on mid-open resizes. Subsequent opens, drag,
  fitHeight mode and desktop are unaffected.