### PR TITLE
Exchange source asset bug, resolves BAB-241

### DIFF
--- a/Models/LayerSwapAuth.ts
+++ b/Models/LayerSwapAuth.ts
@@ -1,7 +1,0 @@
-export class AuthGetCodeResponse {
-    data: {
-        next: Date,
-        already_sent: boolean
-    };
-    error: string;
-}

--- a/components/Swap/Form/NetworkForm.tsx
+++ b/components/Swap/Form/NetworkForm.tsx
@@ -132,9 +132,7 @@ const NetworkForm: FC<Props> = ({ partner }) => {
                             }
                             {
                                 routeValidation.message
-                                    ? <div className="mt-2">
-                                        <ValidationError />
-                                    </div>
+                                    ? <ValidationError />
                                     : null
                             }
                             {

--- a/components/validationError/index.tsx
+++ b/components/validationError/index.tsx
@@ -8,11 +8,13 @@ const ValidationError: React.FC = () => {
     if (!routeValidation.message) return null;
 
     return (
-        <ErrorDisplay
-            icon={routeValidation.details.icon}
-            title={routeValidation.details.title}
-            message={routeValidation.message}
-        />
+        <div className="mt-2">
+            <ErrorDisplay
+                icon={routeValidation.details.icon}
+                title={routeValidation.details.title}
+                message={routeValidation.message}
+            />
+        </div>
     );
 };
 

--- a/context/validationContext.tsx
+++ b/context/validationContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useMemo, ReactNode } from 'react';
 import { useFormikContext } from 'formik';
 import { useQueryState } from './query';
-import { SwapFormValues } from '../components/DTOs/SwapFormValues';
+import { SwapFormValues } from '@/components/DTOs/SwapFormValues';
 import { transformFormValuesToQuoteArgs, useQuoteData } from '@/hooks/useFee';
 import { resolveFormValidation } from '@/hooks/useFormValidation';
 import { useRouteValidation } from '@/hooks/useRouteValidation';
@@ -10,6 +10,7 @@ import { useSelectedAccount } from './swapAccounts';
 import { useSlippageStore } from '@/stores/slippageStore';
 import { useAutoSlippageTest } from '@/hooks/useAutoSlippageTest';
 import { useUsdModeStore } from '@/stores/usdModeStore';
+import useExchangeNetworks from '@/hooks/useExchangeNetworks';
 
 export interface ValidationDetails {
     title?: string;
@@ -54,6 +55,8 @@ export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children
     const shouldTestAutoSlippage = !autoSlippage && !quote && !!values.amount && Number(values.amount) > 0 && !!values.from && !!values.to && !quoteErrorCode && !(isQuoteLoading || isDebouncing);
     const { autoSlippageWouldWork, isTestingAutoSlippage } = useAutoSlippageTest({ values, shouldTest: shouldTestAutoSlippage });
 
+    const { networks: exchangeWithdrawalNetworks, isLoading: exchangeNetworksLoading, isValidating: exchangeNetworksValidating } = useExchangeNetworks({ fromExchange: values.fromExchange?.name, to: values.to?.name, toAsset: values.toAsset?.symbol });
+    const noExchangeWithdrawalRoute = !!values.fromExchange && !!values.to && !!values.toAsset && !exchangeNetworksLoading && !exchangeNetworksValidating && (exchangeWithdrawalNetworks?.length ?? 0) === 0;
     const routeValidation = useRouteValidation(quoteError, !!quote, isQuoteLoading || isDebouncing, autoSlippageWouldWork);
 
     const isUsdMode = useUsdModeStore(s => s.isUsdMode);
@@ -67,7 +70,8 @@ export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children
         isUsdMode,
         sourceAddress: selectedSourceAccount?.address,
         sameAccountNetwork,
-        quoteError
+        quoteError,
+        noExchangeWithdrawalRoute
     })
 
     const value = useMemo(

--- a/hooks/useExchangeNetworks.ts
+++ b/hooks/useExchangeNetworks.ts
@@ -17,7 +17,8 @@ export default function useExchangeNetworks({ fromExchange, to, toAsset }: Props
     const apiClient = new LayerSwapApiClient()
     const {
         data: apiResponse,
-        isLoading
+        isLoading,
+        isValidating
     } = useSWR<ApiResponse<ExchangeNetwork[]>>(exchangeNetworksURL, apiClient.fetcher,
         {
             keepPreviousData: true,
@@ -26,5 +27,5 @@ export default function useExchangeNetworks({ fromExchange, to, toAsset }: Props
         })
     //As the response does not give the statuses and it does not include not active tokens, we can assume all are active
     const networks = useMemo(() => (apiResponse?.data?.map(n => ({ ...n, token: { ...n.token, status: "active" as "active" } }))), [apiResponse])
-    return { networks, isLoading }
+    return { networks, isLoading, isValidating }
 }

--- a/hooks/useFormValidation.ts
+++ b/hooks/useFormValidation.ts
@@ -1,5 +1,5 @@
-import { SwapFormValues } from '../components/DTOs/SwapFormValues';
-import { Address } from '../lib/address';
+import { SwapFormValues } from '@/components/DTOs/SwapFormValues';
+import { Address } from '@/lib/address';
 import { QuoteError } from './useFee';
 import { ceilUsd, floorUsd } from '@/components/utils/formatUsdAmount';
 
@@ -12,7 +12,8 @@ interface Params {
     isUsdMode: boolean,
     sourceAddress: string | undefined,
     sameAccountNetwork?: string | undefined,
-    quoteError?: QuoteError
+    quoteError?: QuoteError,
+    noExchangeWithdrawalRoute?: boolean
 }
 
 export const FORM_VALIDATION_ERROR_CODES = {
@@ -22,7 +23,7 @@ export const FORM_VALIDATION_ERROR_CODES = {
 }
 
 
-export function resolveFormValidation({ values, maxAllowedAmount, minAllowedAmount, minAllowedAmountInUsd, maxAllowedAmountInUsd, isUsdMode, sourceAddress, sameAccountNetwork, quoteError }: Params) {
+export function resolveFormValidation({ values, maxAllowedAmount, minAllowedAmount, minAllowedAmountInUsd, maxAllowedAmountInUsd, isUsdMode, sourceAddress, sameAccountNetwork, quoteError, noExchangeWithdrawalRoute }: Params) {
     let amount = values.amount ? Number(values.amount) : undefined;
 
     // Deposit address flow without exchange: no amount or exchange required
@@ -34,7 +35,10 @@ export function resolveFormValidation({ values, maxAllowedAmount, minAllowedAmou
     if (!values.to) {
         return { message: 'Select destination' };
     }
-    if (!isDepositAddressFlow && !values.fromAsset) {
+    if (noExchangeWithdrawalRoute) {
+        return { message: 'Route not found', code: FORM_VALIDATION_ERROR_CODES.ROUTE_NOT_FOUND };
+    }
+    if (!isDepositAddressFlow && !values.fromExchange && !values.fromAsset) {
         return { message: 'Select source asset' };
     }
     if (!values.toAsset) {
@@ -78,8 +82,8 @@ export function resolveFormValidation({ values, maxAllowedAmount, minAllowedAmou
 
     if (!isDepositAddressFlow) {
         if (
-            values.from?.name.toLowerCase() === sameAccountNetwork?.toLowerCase() ||
-            values.to?.name.toLowerCase() === sameAccountNetwork?.toLowerCase()
+            (values.from?.name && values.from?.name.toLowerCase() === sameAccountNetwork?.toLowerCase()) ||
+            (values.to?.name && values.to?.name.toLowerCase() === sameAccountNetwork?.toLowerCase())
         ) {
             if (
                 sourceAddress &&


### PR DESCRIPTION
fix: prevent wrong/transient submit-button text in exchange (CEX) flow

In the exchange flow the source network/token are derived from the exchange_withdrawal_networks response, not picked by the user, so they lag behind during the fetch. resolveFormValidation read these lagging values and surfaced misleading button text while a route resolved.

- Guard "Select source asset" with !values.fromExchange: the source asset is derived in the exchange flow, so never prompt the user to select it (mirrors the existing "Select source" guard).
- Surface "Route not found" when an exchange has no withdrawal route to the selected destination, gated on the fetch settling (!isLoading && !isValidating) so it doesn't flash mid-resolution. Expose isValidating from useExchangeNetworks and compute noExchangeWithdrawalRoute in the validation context.
- Guard the same-account-network check against undefined from/to names (mirrors useRouteValidation) so undefined === undefined no longer false-fires "Manual Transfer is not supported" while the source is still resolving.
- Move the ValidationError mt-2 spacing into the component.