### PR TITLE
Fix stale USD value and swap path lingering on tab switch

### DIFF
--- a/components/Swap/Form/Tabs.tsx
+++ b/components/Swap/Form/Tabs.tsx
@@ -12,6 +12,12 @@ interface TabsContextType {
 }
 const TabsContext = createContext<TabsContextType | undefined>(undefined)
 
+export const useTabs = () => {
+    const ctx = useContext(TabsContext)
+    if (!ctx) throw new Error('useTabs must be used within <Tabs>')
+    return ctx
+}
+
 interface TabsProps {
     defaultValue: string
     children: ReactNode
@@ -36,7 +42,7 @@ export const TabsList: FC<TabsListProps> = ({ children }) => {
                 onHoverStart={() => setHovered(true)}
                 onHoverEnd={() => setHovered(false)}
                 animate={{ width: hoveredOnDesktop ? 180 : 48 }}
-                className="sm:absolute right-full top-24 overflow-hidden rounded-l-xl max-sm:right-19 max-sm:z-20 max-sm:top-[9px] max-sm:w-fit! max-sm:rounded-lg"
+                className="sm:absolute right-full top-24 overflow-hidden rounded-l-xl max-sm:right-19 max-sm:z-20 max-sm:top-2.25 max-sm:w-fit! max-sm:rounded-lg"
                 transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
             >
                 <div className="flex flex-col bg-secondary-500 h-full p-1.5 sm:p-2 w-full space-y-2 max-sm:flex-row max-sm:space-y-0 max-sm:space-x-2">

--- a/components/Swap/Form/index.tsx
+++ b/components/Swap/Form/index.tsx
@@ -1,6 +1,7 @@
-import { SwapDataProvider } from "@/context/swap";
-import React, { useMemo, useState } from "react";
-import { NetworkExchangeTabs, Tabs, TabsContent } from "./Tabs";
+import { removeSwapPath, SwapDataProvider } from "@/context/swap";
+import React, { useEffect, useMemo, useRef } from "react";
+import { useRouter } from "next/router";
+import { NetworkExchangeTabs, Tabs, TabsContent, useTabs } from "./Tabs";
 import NetworkForm from "./NetworkForm";
 import ExchangeForm from "./ExchangeForm";
 import DepositAddressForm from "./DepositAddressForm";
@@ -29,6 +30,7 @@ export default function Form() {
     const partner = appName && partnerData?.data?.client_id?.toLowerCase() === (appName as string)?.toLowerCase() ? partnerData?.data : undefined
 
     return <Tabs defaultValue={defaultTab}>
+        <SwapPathTabSync />
         {!theme?.header?.hideTabs ? <div className="hidden sm:block">
             <NetworkExchangeTabs />
         </div> : null}
@@ -80,6 +82,23 @@ export default function Form() {
         </TabsContent>
 
     </Tabs>
+}
+
+// The deposit-address flow writes /swap/{id} into the URL (shallow pushState)
+// when it auto-creates a swap. Each tab has its own SwapDataProvider, so on tab
+// switch that provider's swapId is gone but the URL path lingers. Clear it on
+// every tab change. Scoped to tab changes (not unmount) so it never races with
+// real page navigation.
+const SwapPathTabSync = () => {
+    const { activeId } = useTabs()
+    const router = useRouter()
+    const prevActiveId = useRef(activeId)
+    useEffect(() => {
+        if (prevActiveId.current === activeId) return
+        prevActiveId.current = activeId
+        removeSwapPath(router)
+    }, [activeId, router])
+    return null
 }
 
 const defaultTabResolver = ({ from, sourceExchanges, defaultTabQueryParam }: { from: string | undefined, sourceExchanges: ReturnType<typeof useSettingsState>['sourceExchanges'], defaultTabQueryParam: string | undefined }) => {

--- a/hooks/useUsdTokenSync.ts
+++ b/hooks/useUsdTokenSync.ts
@@ -45,6 +45,11 @@ export function useUsdTokenSync({
     const setUsdAmount = useUsdModeStore(s => s.setUsdAmount);
     const toggleMode = useUsdModeStore(s => s.toggleMode);
 
+    // usdAmount lives in a global store that outlives the form. On unmount
+    // (e.g. switching tabs, which resets the rest of the form) clear the value
+    // so it doesn't linger. The persisted isUsdMode preference is left intact.
+    useEffect(() => () => setUsdAmount(''), [setUsdAmount]);
+
     // --- Price resolution with fallback chain ---
 
     // Cache the last quote-derived price so we don't fall back to the token's


### PR DESCRIPTION
- Clear usdAmount on useUsdTokenSync unmount so the USD value resets with the rest of the form when switching tabs (isUsdMode preference is preserved).
- Remove the shallow /swap/{id} URL path on tab change so the deposit- address flow's swap path no longer lingers after navigating to other tabs. Scoped to tab changes (not unmount) to avoid racing with real page navigation.