### PR TITLE
Rate not available handling, resolves BAB-259

### DIFF
--- a/hooks/useFormValidation.ts
+++ b/hooks/useFormValidation.ts
@@ -19,6 +19,7 @@ interface Params {
 
 export const FORM_VALIDATION_ERROR_CODES = {
     ROUTE_NOT_FOUND: "ROUTE_NOT_FOUND",
+    RATE_NOT_AVAILABLE: "RATE_NOT_AVAILABLE",
     MIN_AMOUNT_ERROR: "MIN_AMOUNT_ERROR",
     MAX_AMOUNT_ERROR: "MAX_AMOUNT_ERROR",
 }
@@ -101,7 +102,11 @@ export function resolveFormValidation({ values, maxAllowedAmount, minAllowedAmou
     }
 
     const quoteErrorCode = quoteError?.response?.data?.error?.code || quoteError?.code;
+    const quoteErrorMessage = quoteError?.response?.data?.error?.message || quoteError?.message;
     if (quoteError && quoteErrorCode !== "QUOTE_REQUIRES_NO_DEPOSIT_ADDRESS") {
+        if (quoteErrorCode === "ROUTE_NOT_FOUND_ERROR" && quoteErrorMessage === "Rate not available") {
+            return { message: 'Price impact too high', code: FORM_VALIDATION_ERROR_CODES.RATE_NOT_AVAILABLE };
+        }
         return { message: 'Route not found', code: FORM_VALIDATION_ERROR_CODES.ROUTE_NOT_FOUND };
     }
 

--- a/hooks/useRouteValidation.tsx
+++ b/hooks/useRouteValidation.tsx
@@ -20,6 +20,7 @@ export function useRouteValidation(quoteError?: QuoteError, hasQuote?: boolean, 
     const selectedSourceAccount = useSelectedAccount("from", from?.name);
     const query = useQueryState();
     const quoteErrorCode = quoteError?.response?.data?.error?.code || quoteError?.code;
+    const quoteErrorMessage = quoteError?.response?.data?.error?.message || quoteError?.message;
     let validationMessage: string = '';
     let validationDetails: ValidationDetails = {};
 
@@ -44,6 +45,11 @@ export function useRouteValidation(quoteError?: QuoteError, hasQuote?: boolean, 
     if (quoteErrorCode === "QUOTE_REQUIRES_NO_DEPOSIT_ADDRESS" && !isExtendedSourceNetwork(from?.name)) {
         validationDetails = { title: 'Manual swapping is not supported', type: 'warning', icon: <RouteOff className={ICON_CLASSES_WARNING} /> };
         validationMessage = `Swaps via manual transfer are not supported for this route. Please select a wallet to send from.`;
+    }
+
+    if (quoteErrorCode === "ROUTE_NOT_FOUND_ERROR" && quoteErrorMessage === "Rate not available") {
+        validationDetails = { title: 'Price impact too high', type: 'warning', icon: <RouteOff className={ICON_CLASSES_WARNING} /> };
+        validationMessage = `The price impact for this amount is too high to swap. Try a smaller amount.`;
     }
 
     const value = useMemo(() => ({


### PR DESCRIPTION
Distinguish high price impact from missing route in quote errors

The backend returns ROUTE_NOT_FOUND_ERROR with "Rate not available" when a route exists but the price impact at the entered amount exceeds the threshold. We were collapsing this into a misleading "Route not found" message even though the route is valid (limits succeed).

Detect this specific error and surface accurate messaging: the swap button now reads "Price impact too high" and the help box explains the price impact is too high and to try a smaller amount. Other quote errors keep the "Route not found" fallback.