### PR TITLE
fix: unify destination address-picker row styling

### DIFF
--- a/components/Input/Address/AddressPicker/AddressBook.tsx
+++ b/components/Input/Address/AddressPicker/AddressBook.tsx
@@ -1,10 +1,9 @@
 import { Command, CommandGroup, CommandItem, CommandList } from "@/components/shadcn/command";
 import { Address } from "@/lib/address";
-import FilledCheck from "@/components/icons/FilledCheck";
 import { AddressGroup, AddressItem } from ".";
 import { NetworkRoute } from "@/Models/Network";
 import { FC } from "react";
-import AddressWithIcon from "./AddressWithIcon";
+import AddressPickerItem from "./AddressPickerItem";
 import { Partner } from "@/Models/Partner";
 import { Wallet } from "@/Models/WalletProvider";
 import { BookOpen } from "lucide-react";
@@ -41,21 +40,8 @@ const AddressBook: FC<AddressBookProps> = ({ addressBook, onSelectAddress, desti
                                 const isBookEntry = !!resolveName(item.address, destination)
                                 const handleRemove = onRemove && item.group === AddressGroup.ManualAdded ? () => onRemove(item.address, isBookEntry) : undefined
                                 return (
-                                    <CommandItem key={item.address} onSelect={() => onSelectAddress(item.address, item.wallet)} className={`group/addressItem !px-3 !py-3 rounded-lg hover:bg-secondary-600 w-full transition duration-200 bg-secondary-500 ${isSelected && 'bg-secondary-400'}`}>
-                                        <div className={`flex items-center justify-between w-full`}>
-                                            <AddressWithIcon
-                                                addressItem={item}
-                                                partner={partner}
-                                                network={destination}
-                                                onRemove={handleRemove}
-                                            />
-                                            <div className="flex h-6 items-center px-1">
-                                                {
-                                                    isSelected &&
-                                                    <FilledCheck />
-                                                }
-                                            </div>
-                                        </div>
+                                    <CommandItem key={item.address} onSelect={() => onSelectAddress(item.address, item.wallet)} className="!p-0 outline-none">
+                                        <AddressPickerItem item={item} network={destination} partner={partner} selected={isSelected} onRemove={handleRemove} />
                                     </CommandItem>
                                 )
                             })}

--- a/components/Input/Address/AddressPicker/AddressPickerItem.tsx
+++ b/components/Input/Address/AddressPicker/AddressPickerItem.tsx
@@ -1,0 +1,25 @@
+import { FC } from "react";
+import clsx from "clsx";
+import { AddressItem } from ".";
+import { NetworkRoute } from "@/Models/Network";
+import { Partner } from "@/Models/Partner";
+import AddressWithIcon from "./AddressWithIcon";
+import FilledCheck from "@/components/icons/FilledCheck";
+type Props = {
+    item: AddressItem;
+    network?: NetworkRoute;
+    partner?: Partner;
+    selected?: boolean;
+    onRemove?: () => void;
+    onClick?: () => void;
+    className?: string;
+}
+
+const AddressPickerItem: FC<Props> = ({ item, network, partner, selected, onRemove, onClick, className }) => (
+    <div onClick={onClick} className={clsx('group/addressItem w-full flex items-center justify-between gap-2 rounded-lg bg-secondary-500 p-3 transition duration-200 hover:bg-secondary-400 cursor-pointer', selected && 'bg-secondary-400', className)}>
+        <AddressWithIcon addressItem={item} partner={partner} network={network} onRemove={onRemove} />
+        {selected && <div className="flex h-6 items-center px-1"><FilledCheck /></div>}
+    </div>
+)
+
+export default AddressPickerItem

--- a/components/Input/Address/AddressPicker/ManualAddressInput.tsx
+++ b/components/Input/Address/AddressPicker/ManualAddressInput.tsx
@@ -6,7 +6,7 @@ import { NetworkType } from "@/Models/Network";
 import FilledX from "@/components/icons/FilledX";
 import { AddressGroup, AddressItem } from ".";
 import { Address } from "@/lib/address";
-import AddressWithIcon from "./AddressWithIcon";
+import AddressPickerItem from "./AddressPickerItem";
 import SaveToBookInline from "@/components/AddressBook/SaveToBookInline";
 import { Wallet } from "@/Models/WalletProvider";
 import { FormikHelpers } from "formik";
@@ -111,9 +111,7 @@ const ManualAddressInput: FC<AddressInput> = ({ manualAddress, setManualAddress,
 
                 {
                     manualAddress && !errorMessage &&
-                    <div onClick={handleSaveNewAddress} className={`group/addressItem text-left min-h-12 cursor-pointer space-x-2 bg-secondary-600 shadow-xl flex text-sm rounded-md items-center w-full transform hover:bg-secondary-700 transition duration-200 p-3 hover:shadow-xl mt-3`}>
-                        <AddressWithIcon addressItem={addressFromList || { address: manualAddress, group: AddressGroup.ManualAdded }} partner={partner} network={destination} />
-                    </div>
+                    <AddressPickerItem item={addressFromList || { address: manualAddress, group: AddressGroup.ManualAdded }} network={destination} partner={partner} onClick={handleSaveNewAddress} className="mt-3 min-h-12" />
                 }
                 {canSaveToAddressBook && <SaveToBookInline key={manualAddress} address={manualAddress} network={destination!} />}
             </div>


### PR DESCRIPTION
The address-book entry and the searched-address preview each wrapped the shared AddressWithIcon in their own divergent container: the book row hovered the wrong way (bg-secondary-600) with no pointer cursor, and the searched preview was a darker bg-secondary-600 box with shadow/transform.

Extract a shared AddressPickerItem that renders the row at the connected-wallet reference style (bg-secondary-500, lightening hover:bg-secondary-400, pointer cursor, rounded-lg) and use it in both AddressBook and ManualAddressInput. All three picker rows now match.