### PR TITLE
[codex] Fix Polymarket base path issues

### DIFF
--- a/components/Common/ImageWithFallback.tsx
+++ b/components/Common/ImageWithFallback.tsx
@@ -1,15 +1,28 @@
 import Image, { ImageProps } from "next/image";
+import { useRouter } from "next/router";
 import React, { forwardRef, useCallback, useEffect, useState } from "react";
 import LogoPlaceholder from "../icons/LogoPlaceholder";
 
+function withBasePath(src: ImageProps["src"], basePath: string): ImageProps["src"] {
+    if (typeof src !== "string" || !basePath || !src.startsWith("/") || src.startsWith("//")) {
+        return src;
+    }
+    if (src === basePath || src.startsWith(`${basePath}/`)) {
+        return src;
+    }
+    return `${basePath}${src}`;
+}
+
 export const ImageWithFallback = forwardRef<HTMLImageElement, ImageProps>(({ src, ...props }, ref) => {
-    const [imgSrc, setImgSrc] = useState(src);
+    const basePath = useRouter().basePath || "";
+    const resolvedSrc = withBasePath(src, basePath);
+    const [imgSrc, setImgSrc] = useState(resolvedSrc);
     const [hasError, setHasError] = useState(false);
 
     useEffect(() => {
-        setImgSrc(src);
+        setImgSrc(resolvedSrc);
         setHasError(false);
-    }, [src])
+    }, [resolvedSrc])
 
     const handleError = useCallback(() => {
         setHasError(true);

--- a/components/Swap/Withdraw/Wallet/WithdrawalProviders/Polymarket/usePolymarketWithdrawal.ts
+++ b/components/Swap/Withdraw/Wallet/WithdrawalProviders/Polymarket/usePolymarketWithdrawal.ts
@@ -269,7 +269,7 @@ export function usePolymarketWithdrawal({ swapBasicData, refuel, swapId }: Withd
                     ifMounted(() => setError(resolvePolymarketError('no polymarket account')))
                     return
                 }
-                const nonce = await getRelayerNonce(sourceAddress, 'SAFE')
+                const nonce = await getRelayerNonce(sourceAddress, 'SAFE', basePath)
                 buildRequest = () => buildSafeBatchRequest({ walletClient, fromEoa, safe: funder.address, calls, nonce })
             }
 

--- a/lib/wallets/polymarket/relayerClient.ts
+++ b/lib/wallets/polymarket/relayerClient.ts
@@ -86,17 +86,17 @@ async function proxyGet<T>(params: Record<string, string>, basePath: string): Pr
 /** Relayer signer type. The nonce is always keyed on the owner EOA + the funder type. */
 export type RelayerSignerType = 'SAFE' | 'PROXY' | 'WALLET'
 
-export async function getRelayerNonce(ownerEoa: string, type: RelayerSignerType, basePath = ''): Promise<string> {
+export async function getRelayerNonce(ownerEoa: string, type: RelayerSignerType, basePath: string): Promise<string> {
     const data = await proxyGet<{ nonce: string }>({ action: 'nonce', address: ownerEoa, type }, basePath)
     return data.nonce
 }
 
-export async function isPolymarketDeployed(address: string, type: RelayerSignerType, basePath = ''): Promise<boolean> {
+export async function isPolymarketDeployed(address: string, type: RelayerSignerType, basePath: string): Promise<boolean> {
     const data = await proxyGet<{ deployed: boolean }>({ action: 'deployed', address, type }, basePath)
     return !!data.deployed
 }
 
-export async function submitRelayerTransaction(request: RelayerSubmittable, basePath = ''): Promise<RelayerSubmitResponse> {
+export async function submitRelayerTransaction(request: RelayerSubmittable, basePath: string): Promise<RelayerSubmitResponse> {
     const res = await fetch(proxyPath(basePath), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -106,7 +106,7 @@ export async function submitRelayerTransaction(request: RelayerSubmittable, base
     return res.json() as Promise<RelayerSubmitResponse>
 }
 
-export async function getRelayerTransaction(id: string, basePath = ''): Promise<RelayerTransaction[]> {
+export async function getRelayerTransaction(id: string, basePath: string): Promise<RelayerTransaction[]> {
     const data = await proxyGet<RelayerTransaction[] | { transactions?: RelayerTransaction[] }>({ action: 'transaction', id }, basePath)
     return Array.isArray(data) ? data : (data.transactions ?? [])
 }


### PR DESCRIPTION
Fixes two Polymarket production issues caused by the app being served under `/app`: legacy Safe nonce relay calls now include `router.basePath`, and local public images are prefixed with the same base path before going through `next/image`.

The relayer helper signatures now require `basePath`, so future relay calls do not silently fall back to root `/api/...` URLs.

This resolves both the relay 404 and the Polymarket logo optimizer 400 where `url=/images/polymarket.png` should be `url=/app/images/polymarket.png`.

Validation: `git diff --check` passed; local curl checks show the old optimizer URL returns 400 and the fixed base-path URL returns 200; `pnpm exec tsc --noEmit` still fails on existing missing PNG module declarations in FeeDetails and SwapGuide.