### PR TITLE
fix: hide phone connect hint for extension-only wallets

### DIFF
--- a/components/Input/Address/AddressPicker/ManualAddressInput.tsx
+++ b/components/Input/Address/AddressPicker/ManualAddressInput.tsx
@@ -83,7 +83,7 @@ const ManualAddressInput: FC<AddressInput> = ({ manualAddress, setManualAddress,
                                 handleSaveNewAddress()
                             }
                         }}
-                        className='pr-12 disabled:cursor-not-allowed grow h-12 border border-secondary-800 focus:border-primary leading-4 placeholder:text-primary-text-tertiary/80 focus:placeholder:text-left placeholder:font-normal focus:placeholder:pl-0 placeholder:pl-8 block font-semibold w-full !bg-secondary-500 rounded-lg truncate hover:overflow-x-scroll focus:ring-0 focus:outline-hidden'
+                        className='autofill-secondary pr-12 disabled:cursor-not-allowed grow h-12 border border-secondary-800 focus:border-primary leading-4 placeholder:text-primary-text-tertiary/80 focus:placeholder:text-left placeholder:font-normal focus:placeholder:pl-0 placeholder:pl-8 block font-semibold w-full !bg-secondary-500 rounded-lg truncate hover:overflow-x-scroll focus:ring-0 focus:outline-hidden'
                     />
                     {
                         !isFocused && !manualAddress &&

--- a/components/WalletModal/InstalledExtensionNotFound.tsx
+++ b/components/WalletModal/InstalledExtensionNotFound.tsx
@@ -24,7 +24,7 @@ export const InstalledExtensionNotFound: FC<{
                 <div className="text-center">
                     <p className="text-base font-medium text-primary-text">{selectedConnector?.name} not detected</p>
                     <p className="text-sm font-normal text-secondary-text mt-1">
-                        Install the extension or connect with your phone
+                        {selectedConnector?.hasBrowserExtension ? "Install the extension or connect with your phone" : "Install the extension to continue"}
                     </p>
                 </div>
             </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -94,6 +94,14 @@
   max-height: var(--radix-popper-available-height);
 }
 
+@utility autofill-secondary {
+  &:-webkit-autofill,
+  &:autofill {
+    box-shadow: inset 0 0 0 1000px var(--color-secondary-500) !important;
+    -webkit-text-fill-color: var(--color-primary-text) !important;
+  }
+}
+
 @layer utilities {
 
   /* Chrome, Safari, Edge, Opera */


### PR DESCRIPTION
Show "Install the extension to continue" instead of the misleading "or connect with your phone" for connectors without mobile support (e.g. Fuel, TRON, Bitcoin).