### PR TITLE
Transactions fetching for many wallets, resolves BAB-287

### DIFF
--- a/components/SwapHistory/Filters/CheckboxRow.tsx
+++ b/components/SwapHistory/Filters/CheckboxRow.tsx
@@ -9,21 +9,28 @@ type CheckboxRowProps = {
     label: string
     sublabel?: string
     className?: string
+    disabled?: boolean
 }
 
-const CheckboxRow: FC<CheckboxRowProps> = ({ checked, onToggle, icon, label, sublabel, className }) => (
+const CheckboxRow: FC<CheckboxRowProps> = ({ checked, onToggle, icon, label, sublabel, className, disabled = false }) => (
     <div
         role="checkbox"
         aria-checked={checked}
-        tabIndex={0}
-        onClick={onToggle}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        onClick={disabled ? undefined : onToggle}
         onKeyDown={(e) => {
+            if (disabled) return
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
                 onToggle()
             }
         }}
-        className={cn('w-full flex items-center gap-3 px-3 py-2 rounded-2xl text-sm hover:bg-secondary-400 text-primary-text cursor-pointer select-none', className)}
+        className={cn(
+            'w-full flex items-center gap-3 px-3 py-2 rounded-2xl text-sm text-primary-text select-none',
+            disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-secondary-400 cursor-pointer',
+            className,
+        )}
     >
         {icon ? <span className="w-5 h-5 flex items-center justify-center shrink-0">{icon}</span> : null}
         <span className="flex-1 min-w-0 text-left">

--- a/components/SwapHistory/Filters/WalletsDropdown.tsx
+++ b/components/SwapHistory/Filters/WalletsDropdown.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Settings2 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '../../shadcn/popover'
 import { Wallet } from '@/Models/WalletProvider'
 import { Address } from '@/lib/address'
+import { HistoryWalletAddress, MAX_HISTORY_ADDRESSES } from '@/lib/historyWalletAddresses'
 import CheckboxRow from './CheckboxRow'
 import { filterChipClasses } from './chipStyles'
 import VaulDrawer from '../../modal/vaulModal'
@@ -11,6 +12,7 @@ import { useAddressNameFinder } from '@/stores/addressBookStore'
 
 type WalletsDropdownProps = {
     wallets: Wallet[]
+    addresses: HistoryWalletAddress[]
     selectedAddresses: string[]
     toggle: (address: string) => void
     count: number
@@ -23,32 +25,24 @@ type Row = {
     icon: React.ReactNode
 }
 
-const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, selectedAddresses, toggle, count }) => {
+const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, addresses, selectedAddresses, toggle, count }) => {
     const [open, setOpen] = useState(false)
     const [manageOpen, setManageOpen] = useState(false)
     const disabled = wallets.length === 0
     const label = count > 0 ? `Wallets (${count})` : 'Wallets'
     const findName = useAddressNameFinder()
 
-    const rows = useMemo<Row[]>(() => {
-        const seen = new Set<string>()
-        const out: Row[] = []
-        for (const w of wallets) {
-            for (const address of w.addresses) {
-                const addr = new Address(address, null, w.providerName)
-                if (seen.has(addr.normalized)) continue
-                seen.add(addr.normalized)
-                const Icon = w.icon
-                out.push({
-                    address,
-                    label: findName(address, null, w.providerName) || w.displayName || w.providerName,
-                    short: addr.toShortString(),
-                    icon: Icon ? <Icon className="w-5 h-5" /> : null,
-                })
-            }
+    const rows = useMemo<Row[]>(() => addresses.map(({ address, rawAddress, wallet, network }) => {
+        const addr = new Address(rawAddress, network, wallet.providerName)
+        const Icon = wallet.icon
+
+        return {
+            address,
+            label: findName(rawAddress, network, wallet.providerName) || wallet.displayName || wallet.providerName,
+            short: addr.toShortString(),
+            icon: Icon ? <Icon className="w-5 h-5" /> : null,
         }
-        return out
-    }, [wallets, findName])
+    }), [addresses, findName])
 
     return (
         <>
@@ -61,17 +55,24 @@ const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, selectedAddresses,
                 </PopoverTrigger>
                 <PopoverContent align="start" className="p-1 w-64 overflow-hidden">
                     <div className="max-h-72 overflow-y-auto styled-scroll">
-                        {rows.map(({ address, label, short, icon }) => (
-                            <CheckboxRow
-                                key={address}
-                                checked={selectedAddresses.includes(address)}
-                                onToggle={() => toggle(address)}
-                                icon={icon}
-                                label={label}
-                                sublabel={short}
-                            />
-                        ))}
+                        {rows.map(({ address, label, short, icon }) => {
+                            const checked = selectedAddresses.includes(address)
+                            const isLimitReached = selectedAddresses.length >= MAX_HISTORY_ADDRESSES
+
+                            return (
+                                <CheckboxRow
+                                    key={address}
+                                    checked={checked}
+                                    disabled={!checked && isLimitReached}
+                                    onToggle={() => toggle(address)}
+                                    icon={icon}
+                                    label={label}
+                                    sublabel={short}
+                                />
+                            )
+                        })}
                     </div>
+                    <p className="px-3 py-2 text-xs text-secondary-text">Select up to {MAX_HISTORY_ADDRESSES} addresses</p>
                     {wallets.length > 0 && rows.length > 0 ? (
                         <div className="mx-3 my-1 h-px bg-secondary-400" />
                     ) : null}

--- a/components/SwapHistory/Filters/WalletsDropdown.tsx
+++ b/components/SwapHistory/Filters/WalletsDropdown.tsx
@@ -58,12 +58,13 @@ const WalletsDropdown: FC<WalletsDropdownProps> = ({ wallets, addresses, selecte
                         {rows.map(({ address, label, short, icon }) => {
                             const checked = selectedAddresses.includes(address)
                             const isLimitReached = selectedAddresses.length >= MAX_HISTORY_ADDRESSES
+                            const isLastRequiredSelection = addresses.length > MAX_HISTORY_ADDRESSES && checked && selectedAddresses.length === 1
 
                             return (
                                 <CheckboxRow
                                     key={address}
                                     checked={checked}
-                                    disabled={!checked && isLimitReached}
+                                    disabled={(!checked && isLimitReached) || isLastRequiredSelection}
                                     onToggle={() => toggle(address)}
                                     icon={icon}
                                     label={label}

--- a/components/SwapHistory/Filters/index.tsx
+++ b/components/SwapHistory/Filters/index.tsx
@@ -5,15 +5,18 @@ import WalletsDropdown from './WalletsDropdown'
 import NetworksDropdown from './NetworksDropdown'
 import ClearAllButton from './ClearAllButton'
 import { FilterNetworkOption } from './types'
+import { HistoryWalletAddress } from '@/lib/historyWalletAddresses'
 
 type FiltersProps = {
     searchQuery: string
     setSearchQuery: (v: string) => void
     walletAddresses: string[]
+    walletSelectionCustomized: boolean
     toggleWalletAddress: (address: string) => void
     networkNames: string[]
     toggleNetworkName: (name: string) => void
     wallets: Wallet[]
+    historyWalletAddresses: HistoryWalletAddress[]
     networks: FilterNetworkOption[]
     onClearAll: () => void
 }
@@ -22,16 +25,16 @@ const Filters: FC<FiltersProps> = ({
     searchQuery,
     setSearchQuery,
     walletAddresses,
+    walletSelectionCustomized,
     toggleWalletAddress,
     networkNames,
     toggleNetworkName,
     wallets,
+    historyWalletAddresses,
     networks,
     onClearAll,
 }) => {
-    const hasAny =
-        walletAddresses.length > 0 ||
-        networkNames.length > 0
+    const hasAny = walletSelectionCustomized || networkNames.length > 0
 
     return (
         <div className="space-y-2 pb-3">
@@ -44,6 +47,7 @@ const Filters: FC<FiltersProps> = ({
             <div className="flex flex-wrap items-center gap-2">
                 <WalletsDropdown
                     wallets={wallets}
+                    addresses={historyWalletAddresses}
                     selectedAddresses={walletAddresses}
                     toggle={toggleWalletAddress}
                     count={walletAddresses.length}

--- a/components/SwapHistory/History.tsx
+++ b/components/SwapHistory/History.tsx
@@ -9,7 +9,6 @@ import { groupBy } from "../utils/groupBy"
 import ConnectButton from "../buttons/connectButton"
 import { useVirtualizer } from '../../lib/virtual'
 import SwapDetails from "./SwapDetailsComponent"
-import { Address } from "../../lib/address";
 import { useSettingsState } from "../../context/settings";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "../shadcn/accordion";
 import { useSwapHistoryData } from "../../hooks/useSwapHistoryData";
@@ -25,6 +24,7 @@ import { SwapDataProvider, SwapDataStateContext } from '@/context/swap';
 import type { Wallet } from '@/Models/WalletProvider';
 import { useSwapTransactionStore } from '@/stores/swapTransactionStore';
 import AppSettings from '@/lib/AppSettings';
+import { getHistoryWalletAddresses, MAX_HISTORY_ADDRESSES } from '@/lib/historyWalletAddresses';
 
 type ListProps = {
     statuses?: string | number;
@@ -36,36 +36,25 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
     const { networks } = useSettingsState()
     const { wallets } = useWallet()
 
+    const historyWalletAddresses = useMemo(
+        () => getHistoryWalletAddresses(wallets, networks),
+        [wallets, networks]
+    )
+
+    const historyAddressValues = useMemo(
+        () => historyWalletAddresses.map(item => item.address),
+        [historyWalletAddresses]
+    )
+
     const {
         searchQuery, setSearchQuery,
-        walletAddresses, selectedWalletAddrs, toggleWalletAddress,
+        walletAddresses, walletSelectionCustomized, toggleWalletAddress,
         networkNames, toggleNetworkName,
         clearFilters,
         filtersActive,
-    } = useHistoryFilters({ wallets })
+    } = useHistoryFilters({ addresses: historyAddressValues })
 
-    const { allAddresses, normalizedByRaw } = useMemo(() => {
-        const all = new Set<string>()
-        const map = new Map<string, string>()
-        for (const w of wallets) {
-            const network = networks.find(n => n.chain_id == w.chainId) || null
-            for (const addr of w.addresses) {
-                const normalized = new Address(addr, network, w.providerName).normalized
-                all.add(normalized)
-                map.set(addr, normalized)
-            }
-        }
-        return { allAddresses: Array.from(all), normalizedByRaw: map }
-    }, [wallets, networks])
-
-    const effectiveAddresses = useMemo(() => {
-        if (!selectedWalletAddrs || selectedWalletAddrs.length === 0) return allAddresses
-        const out = new Set<string>()
-        for (const a of selectedWalletAddrs) out.add(normalizedByRaw.get(a) ?? a)
-        return Array.from(out)
-    }, [selectedWalletAddrs, allAddresses, normalizedByRaw])
-
-    const { pendingDeposit, completed, isLoadingAny, isValidatingAny } = useSwapHistoryData(effectiveAddresses, networkNames)
+    const { pendingDeposit, completed, isLoadingAny, isValidatingAny } = useSwapHistoryData(walletAddresses, networkNames)
     const search = useSwapByTransactionHash(searchQuery)
 
     const networkOptions = useMemo<FilterNetworkOption[]>(() =>
@@ -80,18 +69,21 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
             walletAddresses={walletAddresses}
+            walletSelectionCustomized={walletSelectionCustomized}
             toggleWalletAddress={toggleWalletAddress}
             networkNames={networkNames}
             toggleNetworkName={toggleNetworkName}
             wallets={wallets}
+            historyWalletAddresses={historyWalletAddresses}
             networks={networkOptions}
             onClearAll={clearFilters}
         />
     ), [
         wallets,
+        historyWalletAddresses,
         networkOptions,
         searchQuery, setSearchQuery,
-        walletAddresses, toggleWalletAddress,
+        walletAddresses, walletSelectionCustomized, toggleWalletAddress,
         networkNames, toggleNetworkName,
         clearFilters,
     ])
@@ -102,6 +94,11 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
     return (
         <div className="relative flex flex-col h-full min-h-0">
             {filtersNode}
+            {historyWalletAddresses.length > MAX_HISTORY_ADDRESSES ? (
+                <p className="pb-3 text-sm text-secondary-text">
+                    Showing swaps for {walletAddresses.length} of {historyWalletAddresses.length} connected wallet addresses. Select wallets to change which addresses are included.
+                </p>
+            ) : null}
             <div className="flex-1 min-h-0">
                 <SwapsList
                     search={search}

--- a/components/SwapHistory/History.tsx
+++ b/components/SwapHistory/History.tsx
@@ -48,13 +48,14 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
 
     const {
         searchQuery, setSearchQuery,
-        walletAddresses, walletSelectionCustomized, toggleWalletAddress,
+        walletAddresses, selectedWalletAddrs, walletSelectionCustomized, toggleWalletAddress,
         networkNames, toggleNetworkName,
         clearFilters,
         filtersActive,
     } = useHistoryFilters({ addresses: historyAddressValues })
 
-    const { pendingDeposit, completed, isLoadingAny, isValidatingAny } = useSwapHistoryData(walletAddresses, networkNames)
+    const effectiveAddresses = selectedWalletAddrs ?? historyAddressValues
+    const { pendingDeposit, completed, isLoadingAny, isValidatingAny } = useSwapHistoryData(effectiveAddresses, networkNames)
     const search = useSwapByTransactionHash(searchQuery)
 
     const networkOptions = useMemo<FilterNetworkOption[]>(() =>
@@ -96,7 +97,7 @@ const Comp: FC<ListProps> = ({ onNewTransferClick }) => {
             {filtersNode}
             {historyWalletAddresses.length > MAX_HISTORY_ADDRESSES ? (
                 <p className="pb-3 text-sm text-secondary-text">
-                    Showing swaps for {walletAddresses.length} of {historyWalletAddresses.length} connected wallet addresses. Select wallets to change which addresses are included.
+                    Showing swaps for {effectiveAddresses.length} of {historyWalletAddresses.length} connected wallet addresses. Select wallets to change which addresses are included.
                 </p>
             ) : null}
             <div className="flex-1 min-h-0">

--- a/hooks/useHistoryFilters.ts
+++ b/hooks/useHistoryFilters.ts
@@ -14,6 +14,7 @@ export function useHistoryFilters({ addresses }: Args) {
         () => addresses.slice(0, MAX_HISTORY_ADDRESSES),
         [addresses]
     )
+    const hasAddressLimit = addresses.length > MAX_HISTORY_ADDRESSES
 
     const knownAddresses = useMemo(() => new Set(addresses), [addresses])
 
@@ -27,19 +28,24 @@ export function useHistoryFilters({ addresses }: Args) {
         })
     }, [knownAddresses])
 
-    const walletAddresses = useMemo(() => {
-        if (customWalletAddresses === null) return defaultWalletAddresses
-        return customWalletAddresses.filter(address => knownAddresses.has(address))
-    }, [customWalletAddresses, defaultWalletAddresses, knownAddresses])
+    const selectedWalletAddrs = useMemo<string[] | null>(() => {
+        if (customWalletAddresses !== null)
+            return customWalletAddresses.filter(address => knownAddresses.has(address))
+
+        return hasAddressLimit ? defaultWalletAddresses : null
+    }, [customWalletAddresses, defaultWalletAddresses, hasAddressLimit, knownAddresses])
+
+    const walletAddresses = selectedWalletAddrs ?? []
 
     const toggleWalletAddress = useCallback((address: string) => {
         if (!knownAddresses.has(address)) return
 
         setCustomWalletAddresses(current => {
-            const selected = (current ?? defaultWalletAddresses)
+            const selected = (current ?? (hasAddressLimit ? defaultWalletAddresses : []))
                 .filter(item => knownAddresses.has(item))
 
             if (selected.includes(address)) {
+                if (hasAddressLimit && selected.length === 1) return selected
                 const next = selected.filter(item => item !== address)
                 return next.length > 0 ? next : null
             }
@@ -47,7 +53,7 @@ export function useHistoryFilters({ addresses }: Args) {
             if (selected.length >= MAX_HISTORY_ADDRESSES) return selected
             return [...selected, address]
         })
-    }, [defaultWalletAddresses, knownAddresses])
+    }, [defaultWalletAddresses, hasAddressLimit, knownAddresses])
 
     const toggleNetworkName = useCallback((name: string) => {
         setNetworkNames(prev =>
@@ -69,6 +75,7 @@ export function useHistoryFilters({ addresses }: Args) {
         searchQuery,
         setSearchQuery,
         walletAddresses,
+        selectedWalletAddrs,
         walletSelectionCustomized: customWalletAddresses !== null,
         toggleWalletAddress,
         networkNames,

--- a/hooks/useHistoryFilters.ts
+++ b/hooks/useHistoryFilters.ts
@@ -1,20 +1,53 @@
-import { useCallback, useMemo, useState } from 'react'
-import { Wallet } from '@/Models/WalletProvider'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { MAX_HISTORY_ADDRESSES } from '@/lib/historyWalletAddresses'
 
 type Args = {
-    wallets: Wallet[]
+    addresses: string[]
 }
 
-export function useHistoryFilters({ wallets }: Args) {
+export function useHistoryFilters({ addresses }: Args) {
     const [searchQuery, setSearchQuery] = useState('')
-    const [walletAddresses, setWalletAddresses] = useState<string[]>([])
+    const [customWalletAddresses, setCustomWalletAddresses] = useState<string[] | null>(null)
     const [networkNames, setNetworkNames] = useState<string[]>([])
 
+    const defaultWalletAddresses = useMemo(
+        () => addresses.slice(0, MAX_HISTORY_ADDRESSES),
+        [addresses]
+    )
+
+    const knownAddresses = useMemo(() => new Set(addresses), [addresses])
+
+    useEffect(() => {
+        setCustomWalletAddresses(current => {
+            if (current === null) return null
+
+            const next = current.filter(address => knownAddresses.has(address))
+            if (next.length === 0) return null
+            return next.length === current.length ? current : next
+        })
+    }, [knownAddresses])
+
+    const walletAddresses = useMemo(() => {
+        if (customWalletAddresses === null) return defaultWalletAddresses
+        return customWalletAddresses.filter(address => knownAddresses.has(address))
+    }, [customWalletAddresses, defaultWalletAddresses, knownAddresses])
+
     const toggleWalletAddress = useCallback((address: string) => {
-        setWalletAddresses(prev =>
-            prev.includes(address) ? prev.filter(x => x !== address) : [...prev, address]
-        )
-    }, [])
+        if (!knownAddresses.has(address)) return
+
+        setCustomWalletAddresses(current => {
+            const selected = (current ?? defaultWalletAddresses)
+                .filter(item => knownAddresses.has(item))
+
+            if (selected.includes(address)) {
+                const next = selected.filter(item => item !== address)
+                return next.length > 0 ? next : null
+            }
+
+            if (selected.length >= MAX_HISTORY_ADDRESSES) return selected
+            return [...selected, address]
+        })
+    }, [defaultWalletAddresses, knownAddresses])
 
     const toggleNetworkName = useCallback((name: string) => {
         setNetworkNames(prev =>
@@ -24,30 +57,19 @@ export function useHistoryFilters({ wallets }: Args) {
 
     const clearFilters = useCallback(() => {
         setSearchQuery('')
-        setWalletAddresses([])
+        setCustomWalletAddresses(null)
         setNetworkNames([])
     }, [])
 
-    const knownAddresses = useMemo(() => {
-        const s = new Set<string>()
-        for (const w of wallets) for (const a of w.addresses) s.add(a)
-        return s
-    }, [wallets])
-
-    const selectedWalletAddrs = useMemo<string[] | null>(() => {
-        const addrs = walletAddresses.filter(a => knownAddresses.has(a))
-        return addrs.length > 0 ? addrs : null
-    }, [walletAddresses, knownAddresses])
-
     const filtersActive =
-        (selectedWalletAddrs?.length ?? 0) > 0 ||
+        customWalletAddresses !== null ||
         networkNames.length > 0
 
     return {
         searchQuery,
         setSearchQuery,
         walletAddresses,
-        selectedWalletAddrs,
+        walletSelectionCustomized: customWalletAddresses !== null,
         toggleWalletAddress,
         networkNames,
         toggleNetworkName,

--- a/hooks/useSwapHistoryData.ts
+++ b/hooks/useSwapHistoryData.ts
@@ -5,6 +5,7 @@ import { ApiResponse } from '@/Models/ApiResponse'
 import { SwapStatus } from '@/Models/SwapStatus'
 import { useSwapTransactionStore } from '@/stores/swapTransactionStore'
 import { useExtendedSourceSkin } from './useExtendedSourceSkin'
+import { Address } from '@/lib/address'
 
 export function useSwapHistoryData(addresses?: string[], networks?: string[]) {
     const [revalidateAll, setRevalidateAll] = useState(false)
@@ -137,9 +138,11 @@ export function useSwapHistoryData(addresses?: string[], networks?: string[]) {
         const pendingIds = new Set(pendingDeposit.swaps.map(s => s.swap.id))
 
         const networkSet = networks && networks.length > 0 ? new Set(networks) : null
+        const selectedAddressSet = addresses ? new Set(addresses) : null
 
         for (const swap of localStorageSwaps) {
             if (completedIds.has(swap.swap.id) || pendingIds.has(swap.swap.id)) continue
+            if (selectedAddressSet && !matchesSelectedAddress(swap, selectedAddressSet)) continue
             if (
                 networkSet &&
                 !networkSet.has(swap.swap.source_network.name) &&
@@ -157,7 +160,7 @@ export function useSwapHistoryData(addresses?: string[], networks?: string[]) {
             ...completed,
             swaps: allCompletedSwaps,
         }
-    }, [completed, localStorageSwaps, pendingDeposit.swaps, networks])
+    }, [completed, localStorageSwaps, pendingDeposit.swaps, networks, addresses])
 
     // Apply the extended-source skin only at the output boundary — the internal
     // id-sets and network filtering above operate on the raw backend identity.
@@ -183,4 +186,13 @@ export function useSwapHistoryData(addresses?: string[], networks?: string[]) {
     }
 }
 
+function matchesSelectedAddress(swapResponse: SwapResponse, selectedAddresses: Set<string>) {
+    const { source_address, source_network, destination_address, destination_network } = swapResponse.swap
 
+    const sourceAddress = source_address
+        ? new Address(source_address, source_network).normalized
+        : null
+    const destinationAddress = new Address(destination_address, destination_network).normalized
+
+    return selectedAddresses.has(sourceAddress ?? '') || selectedAddresses.has(destinationAddress)
+}

--- a/lib/historyWalletAddresses.ts
+++ b/lib/historyWalletAddresses.ts
@@ -20,7 +20,7 @@ export function getHistoryWalletAddresses(wallets: Wallet[], networks: NetworkFo
     const addresses: HistoryWalletAddress[] = []
 
     for (const wallet of wallets) {
-        const network = networks.find(item => item.chain_id === wallet.chainId) ?? null
+        const network = networks.find(item => item.chain_id == wallet.chainId) ?? null
 
         for (const rawAddress of wallet.addresses) {
             const address = new Address(rawAddress, network, wallet.providerName).normalized

--- a/lib/historyWalletAddresses.ts
+++ b/lib/historyWalletAddresses.ts
@@ -1,0 +1,35 @@
+import type { Wallet } from '@/Models/WalletProvider'
+import { Address } from '@/lib/address'
+
+export const MAX_HISTORY_ADDRESSES = 6
+
+type NetworkForHistoryAddress = {
+    chain_id?: string | number | null
+    name: string
+}
+
+export type HistoryWalletAddress = {
+    address: string
+    rawAddress: string
+    wallet: Wallet
+    network: NetworkForHistoryAddress | null
+}
+
+export function getHistoryWalletAddresses(wallets: Wallet[], networks: NetworkForHistoryAddress[],): HistoryWalletAddress[] {
+    const seen = new Set<string>()
+    const addresses: HistoryWalletAddress[] = []
+
+    for (const wallet of wallets) {
+        const network = networks.find(item => item.chain_id === wallet.chainId) ?? null
+
+        for (const rawAddress of wallet.addresses) {
+            const address = new Address(rawAddress, network, wallet.providerName).normalized
+            if (seen.has(address)) continue
+
+            seen.add(address)
+            addresses.push({ address, rawAddress, wallet, network })
+        }
+    }
+
+    return addresses
+}


### PR DESCRIPTION
feat: cap swap history filtering at 6 wallet addresses

Limit the swap history wallet filter to MAX_HISTORY_ADDRESSES (6) with a default selection of the first 6 connected addresses. Add UI affordances: disabled checkbox rows once the limit is reached, a "Select up to N" hint, and a banner when more than 6 addresses are connected.

Extract address-list building into lib/historyWalletAddresses.ts, track custom vs default selection in useHistoryFilters (walletSelectionCustomized), and filter localStorage swaps by the selected addresses in useSwapHistoryData.