### PR TITLE
fix(tron): resolve adapter by connector id instead of display name

### DIFF
--- a/components/Input/DestinationWalletPicker.tsx
+++ b/components/Input/DestinationWalletPicker.tsx
@@ -27,7 +27,7 @@ const DestinationWalletPicker = (props: AddressTriggerProps) => {
                     <div className="inline-flex items-center relative px-0.5">
                         <ResolvedIcon addressItem={addressItem} partner={partner} wallet={connectedWallet} destination={destination} />
                     </div>
-                    <div className="text-secondary-text truncate max-w-[90px]">{label}</div>
+                    <div className="text-secondary-text truncate max-w-[110px]">{label}</div>
                     <div className="w-4 h-4 items-center flex text-secondary-text">
                         <ChevronDown className="h-4 w-4" aria-hidden="true" />
                     </div>

--- a/lib/wallets/tron/useTron.ts
+++ b/lib/wallets/tron/useTron.ts
@@ -5,6 +5,7 @@ import { resolveWalletConnectorIcon } from "../utils/resolveWalletIcon";
 import { useSettingsState } from "@/context/settings";
 import { useMemo } from "react";
 import { useSyncProviders } from "../connectors/useSyncProviders";
+import { walletKey } from "../utils/walletKey";
 
 export default function useTron(): WalletProvider {
     const commonSupportedNetworks = [
@@ -48,7 +49,7 @@ export default function useTron(): WalletProvider {
     }
 
     const connectWallet = async ({ connector }: { connector: InternalConnector }) => {
-        const tronConnector = wallets.find(w => w.adapter.name === connector.name)
+        const tronConnector = wallets.find(w => w.adapter.name === connector.id) ?? wallets.find(w => walletKey(w.adapter.name) === walletKey(connector.name))
         if (!tronConnector) throw new Error('Connector not found')
         try {
             select(tronConnector.adapter.name)


### PR DESCRIPTION
resolveNames() can rewrite a connector's display name ("Trust" -> "Trust Wallet") once the WalletConnect registry loads, breaking the exact-name adapter lookup in connectWallet. Route by the raw connector id with a walletKey-normalized fallback, matching the Solana approach.