### PR TITLE
Fix connector provider loading and refactor connector list

### DIFF
--- a/packages/widget/core/src/components/Wallet/WalletModal/ConnectorsGrid.tsx
+++ b/packages/widget/core/src/components/Wallet/WalletModal/ConnectorsGrid.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import type {
+    WalletConnectionProvider,
+    WalletModalConnector,
+} from "@/types/wallet";
+import AppSettings from "@/lib/AppSettings";
+import useWindowDimensions from "@/hooks/useWindowDimensions";
+import { isProviderConnectReady } from "@/hooks/useProvidersConnectReady";
+import { SearchComponent } from "@/components/Input/Search";
+import CircularLoader from "@/components/Icons/CircularLoader";
+import Connector from "./Connector";
+import { ProviderPicker } from "./ProviderPicker";
+import type { ModalWalletProvider } from ".";
+
+type ConnectorsGridProps = {
+    connectors: WalletModalConnector[];
+    featuredProviders: WalletConnectionProvider[];
+    filteredProviders: WalletConnectionProvider[];
+    hasMore: boolean;
+    isLoadingMore: boolean;
+    loadMore: () => Promise<void>;
+    onConnect: (
+        connector: WalletModalConnector,
+        provider: WalletConnectionProvider,
+    ) => void;
+    onSelectProviders: (providerNames: string[]) => void;
+    searchValue: string | undefined;
+    selectedConnector: WalletModalConnector | undefined;
+    selectedProvider: ModalWalletProvider | undefined;
+    selectedProviderNames: string[];
+    setSearchValue: (value: string) => void;
+};
+
+function useScrollActivity() {
+    const [isScrolling, setIsScrolling] = useState(false);
+    const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const handleScroll = useCallback(() => {
+        setIsScrolling(true);
+        if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+        scrollTimeoutRef.current = setTimeout(
+            () => setIsScrolling(false),
+            1000,
+        );
+    }, []);
+
+    useEffect(
+        () => () => {
+            if (scrollTimeoutRef.current)
+                clearTimeout(scrollTimeoutRef.current);
+        },
+        [],
+    );
+
+    return { handleScroll, isScrolling };
+}
+
+function useLoadMoreTrigger(
+    hasMore: boolean,
+    isLoadingMore: boolean,
+    loadMore: () => Promise<void>,
+) {
+    const triggerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const trigger = triggerRef.current;
+        if (!trigger) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && hasMore && !isLoadingMore) {
+                    void loadMore();
+                }
+            },
+            { threshold: 0.1, rootMargin: "100px" },
+        );
+
+        observer.observe(trigger);
+        return () => observer.disconnect();
+    }, [hasMore, isLoadingMore, loadMore]);
+
+    return triggerRef;
+}
+
+export function ConnectorsGrid({
+    connectors,
+    featuredProviders,
+    filteredProviders,
+    hasMore,
+    isLoadingMore,
+    loadMore,
+    onConnect,
+    onSelectProviders,
+    searchValue,
+    selectedConnector,
+    selectedProvider,
+    selectedProviderNames,
+    setSearchValue,
+}: ConnectorsGridProps) {
+    const { isMobile } = useWindowDimensions();
+    const { handleScroll, isScrolling } = useScrollActivity();
+    const loadMoreTriggerRef = useLoadMoreTrigger(
+        hasMore,
+        isLoadingMore,
+        loadMore,
+    );
+
+    return (
+        <div className="text-primary-text space-y-3 flex flex-col w-full styled-scroll relative h-full">
+            <div className="flex items-center gap-3 pt-1">
+                <SearchComponent
+                    searchQuery={searchValue || ""}
+                    setSearchQuery={setSearchValue}
+                    placeholder="Search through 500+ wallets..."
+                    containerClassName="w-full mb-0!"
+                />
+                {(!selectedProvider ||
+                    selectedProvider.isSelectedFromFilter) && (
+                    <ProviderPicker
+                        providers={filteredProviders}
+                        selectedProviderNames={selectedProviderNames}
+                        setSelectedProviderNames={onSelectProviders}
+                    />
+                )}
+            </div>
+            <div
+                onScroll={handleScroll}
+                className={clsx(
+                    "overflow-y-scroll -mr-4 pr-2 scrollbar:!w-1.5 scrollbar:!h-1.5 overflow-x-hidden scrollbar-thumb:bg-transparent",
+                    {
+                        "h-[calc(100svh-160px)]":
+                            isMobile && AppSettings.ThemeData?.enablePortal,
+                        "styled-scroll": isScrolling,
+                    },
+                )}
+            >
+                <div className="grid grid-cols-2 gap-2">
+                    {connectors.map((connector) => {
+                        const provider = featuredProviders.find(
+                            (candidate) =>
+                                candidate.name === connector.providerName,
+                        );
+                        return (
+                            <Connector
+                                key={connector.id}
+                                connector={connector}
+                                onClick={() =>
+                                    provider && onConnect(connector, provider)
+                                }
+                                connectingConnector={selectedConnector}
+                                isRecent={connector.isRecent}
+                                isProviderReady={isProviderConnectReady(
+                                    provider,
+                                )}
+                            />
+                        );
+                    })}
+                </div>
+                {(hasMore || isLoadingMore) && (
+                    <div
+                        ref={loadMoreTriggerRef}
+                        className="col-span-2 flex justify-center items-center pt-2.5"
+                    >
+                        <CircularLoader className="w-8 h-8 animate-spin" />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/ConnectorsList.tsx
+++ b/packages/widget/core/src/components/Wallet/WalletModal/ConnectorsList.tsx
@@ -15,8 +15,8 @@ import { InstalledExtensionNotFound } from "./InstalledExtensionNotFound";
 import { WalletQrCode } from "./WalletQrCode";
 import { LoadingConnect } from "./LoadingConnect";
 import CircularLoader from "@/components/Icons/CircularLoader";
-import { useConnectors } from "@/hooks/useConnectors";
-import { useWalletProvidersRegistry } from "@/context/walletProviders";
+import { connectorKey, useConnectors } from "@/hooks/useConnectors";
+import { areWalletProvidersSettled, useWalletProvidersRegistry, useWalletProvidersSettled } from "@/context/walletProviders";
 import { useWalletDescriptorLoader } from "@/lib/walletConnect/walletDescriptorLoader";
 import { isProviderConnectReady } from "@/hooks/useProvidersConnectReady";
 
@@ -34,6 +34,7 @@ type RequestCapableWalletProvider = WalletConnectionProvider & {
 
 const DEFAULT_BROWSE_PAGE_SIZE = 40
 const SEARCH_PAGE_SIZE = 100
+const PROVIDER_SETTLE_TIMEOUT_MS = 5000
 
 const upsertPaginationState = (
     previous: Record<string, ProviderPaginationState>,
@@ -75,10 +76,12 @@ const canRequestAdditionalConnectors = (provider: WalletConnectionProvider): pro
 const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = ({ onFinish }) => {
     const { providers } = useWallet();
     const registry = useWalletProvidersRegistry()
+    const providersSettled = useWalletProvidersSettled()
     const { loadAll, loadById } = useWalletDescriptorLoader()
     const { setSelectedConnector, selectedProvider, setSelectedProvider, selectedConnector, selectedMultiChainConnector, setSelectedMultiChainConnector } = useConnectModal()
     let [recentConnectors, setRecentConnectors] = usePersistedState<({ providerName?: string, connectorName?: string }[])>([], 'recentConnectors', 'localStorage');
     const [connectionError, setConnectionError] = useState<string | undefined>(undefined);
+    const [settleTimedOut, setSettleTimedOut] = useState(false);
     const [searchValue, setSearchValue] = useState<string | undefined>(undefined)
     const [isScrolling, setIsScrolling] = useState(false);
     const [searchResults, setSearchResults] = useState<InternalConnector[]>([]);
@@ -87,6 +90,7 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
     const scrollTimeout = useRef<any>(null);
     const searchDebounceRef = useRef<any>(null);
     const searchRequestSequenceRef = useRef(0);
+    const initialConnectorsRef = useRef<WalletModalConnector[]>([]);
     const isMobilePlatfrom = isMobile();
     const loadMoreTriggerRef = useRef<HTMLDivElement>(null);
     const { isMobile: isMobileSize } = useWindowDimensions()
@@ -148,32 +152,32 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
         return () => clearTimeout(scrollTimeout.current as any);
     }, []);
 
-    // Reads CURRENT store state (not a render snapshot) to decide whether a
-    // wallet is exposed by more than one ecosystem.
-    const liveMultiChain = useCallback((name: string) => {
-        const lower = name.toLowerCase()
-        const providersWith = registry.getEntries().filter(e =>
-            e.store.getState().availableConnectors?.some(c => c.name.toLowerCase() === lower)
-        )
-        return providersWith.length > 1
+    // Reads CURRENT store state (not a render snapshot) to decide how many of
+    // the providers in the active modal scope expose this wallet.
+    const liveVariantCount = useCallback((name: string) => {
+        const key = connectorKey(name)
+        const featuredProviderIds = new Set(featuredProvidersRef.current.map(provider => provider.id))
+        return registry.getEntries().filter(entry => {
+            if (!featuredProviderIds.has(entry.id)) return false
+            const state = entry.store.getState()
+            return [...(state.availableConnectors ?? []), ...(state.additionalConnectors ?? [])]
+                .some(candidate => connectorKey(candidate.name) === key)
+        }).length
     }, [registry])
 
-    // Resolves once every provider has finished loading (no stubs left, all
-    // real providers `ready`), bounded by `timeoutMs` so a never-ready ecosystem
-    // can't hang the connect. `loadAll()` only imports lazy descriptor modules;
-    // we then wait for the stores to actually publish their connectors.
-    const awaitProvidersSettled = useCallback(async (timeoutMs = 1200) => {
+    // Async waiter: resolves once every provider has finished loading (no stubs
+    // left, all real providers `ready`), bounded by `timeoutMs` so a never-ready
+    // ecosystem can't hang the connect. `loadAll()` only imports lazy descriptor
+    // modules; we then wait for the stores to actually publish their connectors.
+    const awaitProvidersSettled = useCallback(async (timeoutMs = PROVIDER_SETTLE_TIMEOUT_MS): Promise<boolean> => {
         await loadAll()
-        const settled = () => registry.getEntries().every(e => {
-            const s = e.store.getState()
-            return !s.isStub && s.ready
-        })
-        if (settled()) return
-        await new Promise<void>(resolve => {
+        const settled = () => areWalletProvidersSettled(registry)
+        if (settled()) return true
+        return new Promise<boolean>(resolve => {
             let unsub = () => { }
-            const finish = () => { clearTimeout(timer); unsub(); resolve() }
-            const timer = setTimeout(finish, timeoutMs)
-            unsub = registry.subscribe(() => { if (settled()) finish() })
+            const finish = (didSettle: boolean) => { clearTimeout(timer); unsub(); resolve(didSettle) }
+            const timer = setTimeout(() => finish(false), timeoutMs)
+            unsub = registry.subscribe(() => { if (settled()) finish(true) })
         })
     }, [loadAll, registry])
 
@@ -183,7 +187,7 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
     // trigger the descriptor load and wait — bounded, so a failed chunk
     // import can't hang the connect flow — for the live store to replace the
     // stub in the registry and report `ready`.
-    const awaitLiveProvider = useCallback(async (providerId: string, timeoutMs = 5000): Promise<WalletConnectionProvider | undefined> => {
+    const awaitLiveProvider = useCallback(async (providerId: string, timeoutMs = PROVIDER_SETTLE_TIMEOUT_MS): Promise<WalletConnectionProvider | undefined> => {
         void loadById(providerId)
         const live = () => {
             const state = registry.getEntries().find(e => e.id === providerId)?.store.getState()
@@ -202,33 +206,42 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
     const connect = async (connector: WalletModalConnector, provider: WalletConnectionProvider) => {
         try {
             setConnectionError(undefined)
-            if (connector?.isMultiChain) {
-                setSelectedMultiChainConnector(connector)
-                return;
-            }
+            // When the ecosystem picker calls back, its connector is already a
+            // concrete variant. Do not resolve it back to the top-level wallet
+            // tile or we would reopen the same picker instead of connecting.
+            const isEcosystemSelection = selectedMultiChainConnector !== undefined
             // Multi-ecosystem wallets (e.g. MetaMask: EVM + Solana + Tron) surface
             // their non-EVM connectors only after late-loading providers settle.
-            // If a wallet is clicked while any provider is still loading, the
-            // `isMultiChain` flag may not be final yet — wait (bounded) and
-            // re-check before committing to a single-ecosystem connect, so we
-            // don't skip the ecosystem picker. Scoped to injected/standard
-            // connectors (the only kind that can be multi-ecosystem) so
-            // WalletConnect/registry wallets are never delayed.
-            const providersStillLoading = registry.getEntries().some(e => {
-                const s = e.store.getState()
-                return s.isStub || !s.ready
-            })
-            if (connector?.type === 'injected' && providersStillLoading && !liveMultiChain(connector.name)) {
-                setSelectedConnector(connector)
-                await awaitProvidersSettled()
-                if (liveMultiChain(connector.name)) {
-                    setSelectedConnector(undefined)
-                    setSelectedMultiChainConnector(connector)
-                    return
-                }
+            // Wait BEFORE honoring an existing `isMultiChain` flag: two early
+            // variants already make that flag true, but more variants may still
+            // be loading. Otherwise the early return would freeze an incomplete
+            // connector snapshot in the ecosystem picker.
+            const providersStillLoading = !areWalletProvidersSettled(registry)
+            const shouldWaitForVariants = !isEcosystemSelection
+                && providersStillLoading
+                && (connector?.type === 'injected' || connector?.isMultiChain)
+            let didProvidersSettle = true
+            if (shouldWaitForVariants) {
+                didProvidersSettle = await awaitProvidersSettled()
             }
-            setSelectedConnector(connector)
-            if (connector?.hasBrowserExtension !== false && connector.extensionNotFound && !connector?.showQrCode && !isMobilePlatfrom) return
+
+            if (!didProvidersSettle) {
+                setConnectionError("Wallet providers are still initializing. Please wait a moment and try again.")
+                return
+            }
+
+            const latestConnector = isEcosystemSelection
+                ? connector
+                : initialConnectorsRef.current.find(
+                    current => connectorKey(current.name) === connectorKey(connector.name)
+                ) ?? connector
+            if (!isEcosystemSelection && (latestConnector.isMultiChain || liveVariantCount(connector.name) > 1)) {
+                setSelectedConnector(undefined)
+                setSelectedMultiChainConnector(latestConnector)
+                return
+            }
+            setSelectedConnector(latestConnector)
+            if (latestConnector?.hasBrowserExtension !== false && latestConnector.extensionNotFound && !latestConnector?.showQrCode && !isMobilePlatfrom) return
             // Never call `connectWallet` on a stub — it's a metadata-only
             // no-op that would surface as "Connection didn't complete".
             // Hydrate the real provider first and connect through it.
@@ -241,11 +254,11 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
                 return
             }
 
-            const result = liveProvider.connectWallet && await liveProvider.connectWallet({ connector })
+            const result = liveProvider.connectWallet && await liveProvider.connectWallet({ connector: latestConnector })
 
-            if (result && connector && provider) {
+            if (result && latestConnector && provider) {
                 setRecentConnectors((prev) => {
-                    const next = [{ providerName: provider.name, connectorName: connector.name }];
+                    const next = [{ providerName: provider.name, connectorName: latestConnector.name }];
                     const counts = new Map<string, number>();
                     counts.set(provider.name, 1);
 
@@ -253,7 +266,7 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
                         if (
                             item.providerName &&
                             item.connectorName &&
-                            !(item.providerName === provider.name && item.connectorName === connector.name)
+                            !(item.providerName === provider.name && item.connectorName === latestConnector.name)
                         ) {
                             const count = counts.get(item.providerName) ?? 0;
                             if (count < 3) {
@@ -410,6 +423,17 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
         // nothing changed.
         searchResults: isSearching ? searchResults : undefined,
     });
+    initialConnectorsRef.current = initialConnectors
+
+    // The modal context stores the connector object that was clicked. Keep the
+    // picker pointed at the current derived connector so variants published
+    // after that click replace the stale snapshot instead of being ignored.
+    const currentMultiChainConnector = useMemo(() => {
+        if (!selectedMultiChainConnector) return undefined
+        return initialConnectors.find(
+            connector => connectorKey(connector.name) === connectorKey(selectedMultiChainConnector.name)
+        ) ?? selectedMultiChainConnector
+    }, [initialConnectors, selectedMultiChainConnector])
 
     const activePaginationByProvider = isSearching ? searchPaginationByProvider : browsePaginationByProvider
     const anyProviderHasMore = featuredProviders.some(provider => activePaginationByProvider[provider.name]?.nextPage != null)
@@ -527,6 +551,20 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
         return () => observer.disconnect();
     }, [anyProviderHasMore, anyProviderLoadingMore, loadMore, selectedConnector, selectedMultiChainConnector]);
 
+    useEffect(() => {
+        if (providersSettled) return
+        const timer = setTimeout(() => setSettleTimedOut(true), PROVIDER_SETTLE_TIMEOUT_MS)
+        return () => clearTimeout(timer)
+    }, [providersSettled])
+
+    if (!providersSettled && !settleTimedOut) {
+        return (
+            <div className="flex h-full min-h-80 w-full items-center justify-center py-10">
+                <div className="loader text-[3px]!" />
+            </div>
+        )
+    }
+
     if (selectedConnector?.extensionNotFound && !selectedConnector?.showQrCode && !isMobilePlatfrom) {
         const provider = featuredProviders.find(p => p.name === selectedConnector?.providerName)
         if (!provider) return null
@@ -545,9 +583,9 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
         />
     }
 
-    if (selectedMultiChainConnector) {
+    if (currentMultiChainConnector) {
         return <MultichainConnectorPicker
-            selectedConnector={selectedMultiChainConnector}
+            selectedConnector={currentMultiChainConnector}
             providers={featuredProviders}
             connect={connect}
         />

--- a/packages/widget/core/src/components/Wallet/WalletModal/ConnectorsList.tsx
+++ b/packages/widget/core/src/components/Wallet/WalletModal/ConnectorsList.tsx
@@ -1,650 +1,144 @@
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FC } from "react";
 import useWallet from "@/hooks/useWallet";
-import { useConnectModal, WalletModalConnector } from ".";
-import { InternalConnector, Wallet, WalletConnectionProvider } from "@/types/wallet";
-import clsx from "clsx";
-import useWindowDimensions from "@/hooks/useWindowDimensions";
-import Connector from "./Connector";
-import { usePersistedState } from "@/hooks/usePersistedState";
-import { SearchComponent } from "@/components/Input/Search";
+import { useConnectors } from "@/hooks/useConnectors";
+import { useWalletProvidersSettled } from "@/context/walletProviders";
+import type { Wallet } from "@/types/wallet";
 import { isMobile } from "@/lib/wallets/utils/isMobile";
-import AppSettings from "@/lib/AppSettings";
-import { MultichainConnectorPicker } from "./MultichainConnectorPicker";
-import { ProviderPicker } from "./ProviderPicker";
+import { ConnectorsGrid } from "./ConnectorsGrid";
 import { InstalledExtensionNotFound } from "./InstalledExtensionNotFound";
-import { WalletQrCode } from "./WalletQrCode";
 import { LoadingConnect } from "./LoadingConnect";
-import CircularLoader from "@/components/Icons/CircularLoader";
-import { connectorKey, useConnectors } from "@/hooks/useConnectors";
-import { areWalletProvidersSettled, useWalletProvidersRegistry, useWalletProvidersSettled } from "@/context/walletProviders";
-import { useWalletDescriptorLoader } from "@/lib/walletConnect/walletDescriptorLoader";
-import { isProviderConnectReady } from "@/hooks/useProvidersConnectReady";
+import { MultichainConnectorPicker } from "./MultichainConnectorPicker";
+import { WalletQrCode } from "./WalletQrCode";
+import { useConnectorConnection } from "./hooks/useConnectorConnection";
+import { useConnectorPagination } from "./hooks/useConnectorPagination";
+import { useConnectorProviders } from "./hooks/useConnectorProviders";
+import { useProviderLoadingGate } from "./hooks/useProviderLoadingGate";
+import { useRecentConnectors } from "./hooks/useRecentConnectors";
 
-type ProviderPaginationState = {
-    loaded: boolean;
-    nextPage: number | null;
-    totalCount: number;
-    pageSize: number;
-    isLoading: boolean;
-}
-
-type RequestCapableWalletProvider = WalletConnectionProvider & {
-    requestAdditionalConnectors: NonNullable<WalletConnectionProvider["requestAdditionalConnectors"]>;
-}
-
-const DEFAULT_BROWSE_PAGE_SIZE = 40
-const SEARCH_PAGE_SIZE = 100
-const PROVIDER_SETTLE_TIMEOUT_MS = 5000
-
-const upsertPaginationState = (
-    previous: Record<string, ProviderPaginationState>,
-    providerNames: string[],
-    pageSize: number
-) => {
-    const next = { ...previous }
-
-    for (const providerName of providerNames) {
-        next[providerName] = {
-            loaded: previous[providerName]?.loaded ?? false,
-            nextPage: previous[providerName]?.nextPage ?? null,
-            totalCount: previous[providerName]?.totalCount ?? 0,
-            pageSize: previous[providerName]?.pageSize ?? pageSize,
-            isLoading: true,
-        }
-    }
-
-    return next
-}
-
-const withProviderName = (providerName: string, connectors: InternalConnector[]) => {
-    return connectors.map(connector => ({ ...connector, providerName }))
-}
-
-const clearSearchResultsIfNeeded = (previous: InternalConnector[]) => {
-    return previous.length === 0 ? previous : []
-}
-
-const clearPaginationIfNeeded = (previous: Record<string, ProviderPaginationState>) => {
-    return Object.keys(previous).length === 0 ? previous : {}
-}
-
-const canRequestAdditionalConnectors = (provider: WalletConnectionProvider): provider is RequestCapableWalletProvider => {
-    return typeof provider.requestAdditionalConnectors === "function"
-}
-
-
-const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = ({ onFinish }) => {
+const ConnectorsList: FC<{
+    onFinish: (result: Wallet | undefined) => void;
+}> = ({ onFinish }) => {
     const { providers } = useWallet();
-    const registry = useWalletProvidersRegistry()
-    const providersSettled = useWalletProvidersSettled()
-    const { loadAll, loadById } = useWalletDescriptorLoader()
-    const { setSelectedConnector, selectedProvider, setSelectedProvider, selectedConnector, selectedMultiChainConnector, setSelectedMultiChainConnector } = useConnectModal()
-    let [recentConnectors, setRecentConnectors] = usePersistedState<({ providerName?: string, connectorName?: string }[])>([], 'recentConnectors', 'localStorage');
-    const [connectionError, setConnectionError] = useState<string | undefined>(undefined);
-    const [settleTimedOut, setSettleTimedOut] = useState(false);
-    const [searchValue, setSearchValue] = useState<string | undefined>(undefined)
-    const [isScrolling, setIsScrolling] = useState(false);
-    const [searchResults, setSearchResults] = useState<InternalConnector[]>([]);
-    const [browsePaginationByProvider, setBrowsePaginationByProvider] = useState<Record<string, ProviderPaginationState>>({});
-    const [searchPaginationByProvider, setSearchPaginationByProvider] = useState<Record<string, ProviderPaginationState>>({});
-    const scrollTimeout = useRef<any>(null);
-    const searchDebounceRef = useRef<any>(null);
-    const searchRequestSequenceRef = useRef(0);
-    const initialConnectorsRef = useRef<WalletModalConnector[]>([]);
-    const isMobilePlatfrom = isMobile();
-    const loadMoreTriggerRef = useRef<HTMLDivElement>(null);
-    const { isMobile: isMobileSize } = useWindowDimensions()
-
-    const [selectedProviderNames, setSelectedProviderNames] = useState<string[]>([])
-
-    // These lists feed `useConnectors`' memo deps — keep their identity stable
-    // across unrelated local-state renders (search keystrokes, scroll flags,
-    // pagination), otherwise the full connector resolve/dedupe/sort pipeline
-    // reruns on every render while the modal is open.
-    const filteredProviders = useMemo(() => providers.filter(p => !p.hideFromList), [providers])
-    // `selectedProvider` is a snapshot frozen at connect() time, so it must be
-    // re-resolved against the LIVE provider list — and against `providers`,
-    // not `filteredProviders`: scoped connects can target hidden-from-list
-    // providers (e.g. Paradex), which `filteredProviders` never contains. When
-    // such a modal opened before the provider (or its peers) published their
-    // connectors, the frozen snapshot would keep the list empty until the
-    // modal was closed and reopened.
-    const resolvedSelectedProvider = useMemo(() => (
-        selectedProvider && !selectedProvider.isSelectedFromFilter
-            ? providers.find(p => p.name === selectedProvider.name) || selectedProvider
-            : selectedProvider
-    ), [selectedProvider, providers])
-    const featuredProviders = useMemo(() => (
-        selectedProviderNames.length > 0
-            ? filteredProviders.filter(p => selectedProviderNames.includes(p.name))
-            : (resolvedSelectedProvider ? [resolvedSelectedProvider] : filteredProviders)
-    ), [selectedProviderNames, filteredProviders, resolvedSelectedProvider])
-    const requestCapableFeaturedProviderNamesKey = featuredProviders
-        .filter(canRequestAdditionalConnectors)
-        .map(provider => provider.name)
-        .join("|")
-
-    const featuredProvidersRef = useRef(featuredProviders)
-    const browsePaginationRef = useRef(browsePaginationByProvider)
-    const searchPaginationRef = useRef(searchPaginationByProvider)
-    const currentSearchValue = searchValue?.trim() ?? ""
-    const currentSearchValueRef = useRef(currentSearchValue)
-    const isSearching = currentSearchValue.length >= 2
-
-    const isSearchingRef = useRef(isSearching)
-    featuredProvidersRef.current = featuredProviders
-    browsePaginationRef.current = browsePaginationByProvider
-    searchPaginationRef.current = searchPaginationByProvider
-    currentSearchValueRef.current = currentSearchValue
-    isSearchingRef.current = isSearching
-
-    const handleScroll = () => {
-        setIsScrolling(true);
-
-        if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
-
-        scrollTimeout.current = setTimeout(() => {
-            setIsScrolling(false);
-        }, 1000);
-    };
-
-    useEffect(() => {
-        return () => clearTimeout(scrollTimeout.current as any);
-    }, []);
-
-    // Reads CURRENT store state (not a render snapshot) to decide how many of
-    // the providers in the active modal scope expose this wallet.
-    const liveVariantCount = useCallback((name: string) => {
-        const key = connectorKey(name)
-        const featuredProviderIds = new Set(featuredProvidersRef.current.map(provider => provider.id))
-        return registry.getEntries().filter(entry => {
-            if (!featuredProviderIds.has(entry.id)) return false
-            const state = entry.store.getState()
-            return [...(state.availableConnectors ?? []), ...(state.additionalConnectors ?? [])]
-                .some(candidate => connectorKey(candidate.name) === key)
-        }).length
-    }, [registry])
-
-    // Async waiter: resolves once every provider has finished loading (no stubs
-    // left, all real providers `ready`), bounded by `timeoutMs` so a never-ready
-    // ecosystem can't hang the connect. `loadAll()` only imports lazy descriptor
-    // modules; we then wait for the stores to actually publish their connectors.
-    const awaitProvidersSettled = useCallback(async (timeoutMs = PROVIDER_SETTLE_TIMEOUT_MS): Promise<boolean> => {
-        await loadAll()
-        const settled = () => areWalletProvidersSettled(registry)
-        if (settled()) return true
-        return new Promise<boolean>(resolve => {
-            let unsub = () => { }
-            const finish = (didSettle: boolean) => { clearTimeout(timer); unsub(); resolve(didSettle) }
-            const timer = setTimeout(() => finish(false), timeoutMs)
-            unsub = registry.subscribe(() => { if (settled()) finish(true) })
-        })
-    }, [loadAll, registry])
-
-    // A tile can point at a provider that is still a descriptor stub (e.g. a
-    // multichain variant synthesized from registry metadata before its
-    // ecosystem chunk loaded). The stub's `connectWallet` is a no-op, so
-    // trigger the descriptor load and wait — bounded, so a failed chunk
-    // import can't hang the connect flow — for the live store to replace the
-    // stub in the registry and report `ready`.
-    const awaitLiveProvider = useCallback(async (providerId: string, timeoutMs = PROVIDER_SETTLE_TIMEOUT_MS): Promise<WalletConnectionProvider | undefined> => {
-        void loadById(providerId)
-        const live = () => {
-            const state = registry.getEntries().find(e => e.id === providerId)?.store.getState()
-            return state && !state.isStub && state.ready ? state : undefined
-        }
-        const current = live()
-        if (current) return current
-        return new Promise(resolve => {
-            let unsub = () => { }
-            const finish = () => { clearTimeout(timer); unsub(); resolve(live()) }
-            const timer = setTimeout(finish, timeoutMs)
-            unsub = registry.subscribe(() => { if (live()) finish() })
-        })
-    }, [loadById, registry])
-
-    const connect = async (connector: WalletModalConnector, provider: WalletConnectionProvider) => {
-        try {
-            setConnectionError(undefined)
-            // When the ecosystem picker calls back, its connector is already a
-            // concrete variant. Do not resolve it back to the top-level wallet
-            // tile or we would reopen the same picker instead of connecting.
-            const isEcosystemSelection = selectedMultiChainConnector !== undefined
-            // Multi-ecosystem wallets (e.g. MetaMask: EVM + Solana + Tron) surface
-            // their non-EVM connectors only after late-loading providers settle.
-            // Wait BEFORE honoring an existing `isMultiChain` flag: two early
-            // variants already make that flag true, but more variants may still
-            // be loading. Otherwise the early return would freeze an incomplete
-            // connector snapshot in the ecosystem picker.
-            const providersStillLoading = !areWalletProvidersSettled(registry)
-            const shouldWaitForVariants = !isEcosystemSelection
-                && providersStillLoading
-                && (connector?.type === 'injected' || connector?.isMultiChain)
-            let didProvidersSettle = true
-            if (shouldWaitForVariants) {
-                didProvidersSettle = await awaitProvidersSettled()
-            }
-
-            if (!didProvidersSettle) {
-                setConnectionError("Wallet providers are still initializing. Please wait a moment and try again.")
-                return
-            }
-
-            const latestConnector = isEcosystemSelection
-                ? connector
-                : initialConnectorsRef.current.find(
-                    current => connectorKey(current.name) === connectorKey(connector.name)
-                ) ?? connector
-            if (!isEcosystemSelection && (latestConnector.isMultiChain || liveVariantCount(connector.name) > 1)) {
-                setSelectedConnector(undefined)
-                setSelectedMultiChainConnector(latestConnector)
-                return
-            }
-            setSelectedConnector(latestConnector)
-            if (latestConnector?.hasBrowserExtension !== false && latestConnector.extensionNotFound && !latestConnector?.showQrCode && !isMobilePlatfrom) return
-            // Never call `connectWallet` on a stub — it's a metadata-only
-            // no-op that would surface as "Connection didn't complete".
-            // Hydrate the real provider first and connect through it.
-            let liveProvider = provider
-            if (provider.isStub) {
-                liveProvider = await awaitLiveProvider(provider.id) ?? provider
-            }
-            if (liveProvider.isStub || !liveProvider.ready) {
-                setConnectionError("Wallet provider is still initializing. Please wait a moment and try again.")
-                return
-            }
-
-            const result = liveProvider.connectWallet && await liveProvider.connectWallet({ connector: latestConnector })
-
-            if (result && latestConnector && provider) {
-                setRecentConnectors((prev) => {
-                    const next = [{ providerName: provider.name, connectorName: latestConnector.name }];
-                    const counts = new Map<string, number>();
-                    counts.set(provider.name, 1);
-
-                    (prev || []).forEach(item => {
-                        if (
-                            item.providerName &&
-                            item.connectorName &&
-                            !(item.providerName === provider.name && item.connectorName === latestConnector.name)
-                        ) {
-                            const count = counts.get(item.providerName) ?? 0;
-                            if (count < 3) {
-                                next.push({ providerName: item.providerName, connectorName: item.connectorName });
-                                counts.set(item.providerName, count + 1);
-                            }
-                        }
-                    });
-                    return next;
-                })
-                onFinish(result)
-                setSelectedConnector(undefined)
-            } else {
-                setConnectionError("Connection didn't complete. Please try again.")
-            }
-        } catch (e) {
-            console.log(e)
-            const message = (e?.message || e?.details || '').toLowerCase()
-            if (e?.name === 'WalletWindowClosedError' || message.includes('rejected') || message.includes('denied')) {
-                setConnectionError("You've declined the wallet connection request")
-            } else {
-                setConnectionError(e.message || e.details || 'Something went wrong')
-            }
-        }
-    }
-
-    const handleSelectProvider = (providerNames: string[]) => {
-        setSelectedProviderNames(providerNames)
-        if (providerNames.length === 0) {
-            setSelectedProvider(undefined)
-        } else {
-            const provider = filteredProviders.find(p => p.name === providerNames[0])
-            if (provider) {
-                setSelectedProvider({ ...provider, isSelectedFromFilter: true })
-            }
-        }
-    }
-
-    useEffect(() => {
-        if (isSearching) return
-
-        let cancelled = false
-        const providersToLoad = featuredProvidersRef.current.filter(provider =>
-            provider.requestAdditionalConnectors
-            && !browsePaginationRef.current[provider.name]?.loaded
-            && !browsePaginationRef.current[provider.name]?.isLoading
-        )
-
-        if (providersToLoad.length === 0) return
-
-        setBrowsePaginationByProvider(previous => upsertPaginationState(previous, providersToLoad.map(provider => provider.name), DEFAULT_BROWSE_PAGE_SIZE))
-
-        Promise.all(providersToLoad.map(async (provider) => {
-            try {
-                const result = await provider.requestAdditionalConnectors?.({ page: 1, pageSize: DEFAULT_BROWSE_PAGE_SIZE })
-                return { providerName: provider.name, result }
-            } catch {
-                return { providerName: provider.name, result: undefined }
-            }
-        })).then(results => {
-            if (cancelled) return
-
-            setBrowsePaginationByProvider(previous => {
-                const next = { ...previous }
-
-                for (const { providerName, result } of results) {
-                    next[providerName] = {
-                        loaded: true,
-                        nextPage: result?.nextPage ?? null,
-                        totalCount: result?.totalCount ?? 0,
-                        pageSize: previous[providerName]?.pageSize ?? DEFAULT_BROWSE_PAGE_SIZE,
-                        isLoading: false,
-                    }
-                }
-
-                return next
-            })
-        })
-
-        return () => {
-            cancelled = true
-        }
-    }, [isSearching, requestCapableFeaturedProviderNamesKey])
-
-    useEffect(() => {
-        if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
-
-        if (!isSearching) {
-            searchRequestSequenceRef.current += 1
-            setSearchResults(clearSearchResultsIfNeeded)
-            setSearchPaginationByProvider(clearPaginationIfNeeded)
-            return
-        }
-
-        const requestId = searchRequestSequenceRef.current + 1
-        searchRequestSequenceRef.current = requestId
-        const searchableProviders = featuredProvidersRef.current.filter(canRequestAdditionalConnectors)
-
-        if (searchableProviders.length === 0) {
-            setSearchResults(clearSearchResultsIfNeeded)
-            setSearchPaginationByProvider(clearPaginationIfNeeded)
-            return
-        }
-
-        setSearchPaginationByProvider(previous => upsertPaginationState(previous, searchableProviders.map(provider => provider.name), SEARCH_PAGE_SIZE))
-
-        searchDebounceRef.current = setTimeout(async () => {
-            const query = currentSearchValueRef.current
-            const results = await Promise.all(searchableProviders.map(async (provider) => {
-                try {
-                    const result = await provider.requestAdditionalConnectors({ page: 1, pageSize: SEARCH_PAGE_SIZE, query })
-                    return { providerName: provider.name, result }
-                } catch {
-                    return { providerName: provider.name, result: undefined }
-                }
-            }))
-
-            if (requestId !== searchRequestSequenceRef.current || query !== currentSearchValueRef.current) {
-                return
-            }
-
-            setSearchResults(results.flatMap(({ providerName, result }) => withProviderName(providerName, result?.connectors ?? [])))
-            setSearchPaginationByProvider(previous => {
-                const next = { ...previous }
-
-                for (const { providerName, result } of results) {
-                    next[providerName] = {
-                        loaded: true,
-                        nextPage: result?.nextPage ?? null,
-                        totalCount: result?.totalCount ?? 0,
-                        pageSize: SEARCH_PAGE_SIZE,
-                        isLoading: false,
-                    }
-                }
-
-                return next
-            })
-        }, 300)
-
-        return () => {
-            if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
-        }
-    }, [currentSearchValue, isSearching, requestCapableFeaturedProviderNamesKey])
+    const providersSettled = useWalletProvidersSettled();
+    const showProvidersLoading = useProviderLoadingGate(providersSettled);
+    const isMobilePlatform = isMobile();
 
     const {
-        initialConnectors,
-    } = useConnectors({
+        featuredProviders,
+        filteredProviders,
+        selectedProvider,
+        selectedProviderNames,
+        selectProviders,
+    } = useConnectorProviders(providers);
+
+    const {
+        hasMore,
+        isLoadingMore,
+        loadMore,
+        searchResults,
+        searchValue,
+        setSearchValue,
+    } = useConnectorPagination(featuredProviders);
+
+    const { recentConnectors, rememberConnector } = useRecentConnectors();
+    const { initialConnectors } = useConnectors({
         featuredProviders,
         filteredProviders,
         searchValue,
         recentConnectors,
-        // `undefined` (not a fresh `[]`) while idle — a new array identity
-        // every render would invalidate useConnectors' memos even though
-        // nothing changed.
-        searchResults: isSearching ? searchResults : undefined,
+        searchResults,
     });
-    initialConnectorsRef.current = initialConnectors
 
-    // The modal context stores the connector object that was clicked. Keep the
-    // picker pointed at the current derived connector so variants published
-    // after that click replace the stale snapshot instead of being ignored.
-    const currentMultiChainConnector = useMemo(() => {
-        if (!selectedMultiChainConnector) return undefined
-        return initialConnectors.find(
-            connector => connectorKey(connector.name) === connectorKey(selectedMultiChainConnector.name)
-        ) ?? selectedMultiChainConnector
-    }, [initialConnectors, selectedMultiChainConnector])
+    const {
+        connect,
+        connectionError,
+        currentMultiChainConnector,
+        selectedConnector,
+    } = useConnectorConnection({
+        featuredProviders,
+        initialConnectors,
+        onFinish,
+        rememberConnector,
+    });
 
-    const activePaginationByProvider = isSearching ? searchPaginationByProvider : browsePaginationByProvider
-    const anyProviderHasMore = featuredProviders.some(provider => activePaginationByProvider[provider.name]?.nextPage != null)
-    const anyProviderLoadingMore = featuredProviders.some(provider => activePaginationByProvider[provider.name]?.isLoading)
-
-    const loadMoreInFlightRef = useRef(false)
-
-    const loadMore = useCallback(async () => {
-        if (loadMoreInFlightRef.current) return
-        loadMoreInFlightRef.current = true
-        try {
-            if (isSearchingRef.current) {
-                const query = currentSearchValueRef.current
-                const requestId = searchRequestSequenceRef.current
-                const providersToLoad = featuredProvidersRef.current.filter(provider => {
-                    const state = searchPaginationRef.current[provider.name]
-                    return provider.requestAdditionalConnectors && state?.nextPage != null && !state.isLoading
-                })
-
-                if (providersToLoad.length === 0) return
-
-                setSearchPaginationByProvider(previous => upsertPaginationState(previous, providersToLoad.map(provider => provider.name), SEARCH_PAGE_SIZE))
-
-                const results = await Promise.all(providersToLoad.map(async (provider) => {
-                    const state = searchPaginationRef.current[provider.name]
-                    try {
-                        const result = await provider.requestAdditionalConnectors?.({
-                            page: state?.nextPage ?? 1,
-                            pageSize: state?.pageSize ?? SEARCH_PAGE_SIZE,
-                            query,
-                        })
-                        return { providerName: provider.name, result }
-                    } catch {
-                        return { providerName: provider.name, result: undefined }
-                    }
-                }))
-
-                if (requestId !== searchRequestSequenceRef.current || query !== currentSearchValueRef.current) {
-                    return
-                }
-
-                setSearchResults(previous => [
-                    ...previous,
-                    ...results.flatMap(({ providerName, result }) => withProviderName(providerName, result?.connectors ?? []))
-                ])
-                setSearchPaginationByProvider(previous => {
-                    const next = { ...previous }
-
-                    for (const { providerName, result } of results) {
-                        next[providerName] = {
-                            loaded: true,
-                            nextPage: result?.nextPage ?? null,
-                            totalCount: result?.totalCount ?? previous[providerName]?.totalCount ?? 0,
-                            pageSize: previous[providerName]?.pageSize ?? SEARCH_PAGE_SIZE,
-                            isLoading: false,
-                        }
-                    }
-
-                    return next
-                })
-
-                return
-            }
-
-            const providersToLoad = featuredProvidersRef.current.filter(provider => {
-                const state = browsePaginationRef.current[provider.name]
-                return provider.requestAdditionalConnectors && state?.nextPage != null && !state.isLoading
-            })
-
-            if (providersToLoad.length === 0) return
-
-            setBrowsePaginationByProvider(previous => upsertPaginationState(previous, providersToLoad.map(provider => provider.name), DEFAULT_BROWSE_PAGE_SIZE))
-
-            const results = await Promise.all(providersToLoad.map(async (provider) => {
-                const state = browsePaginationRef.current[provider.name]
-                try {
-                    const result = await provider.requestAdditionalConnectors?.({
-                        page: state?.nextPage ?? 1,
-                        pageSize: state?.pageSize ?? DEFAULT_BROWSE_PAGE_SIZE,
-                    })
-                    return { providerName: provider.name, result }
-                } catch {
-                    return { providerName: provider.name, result: undefined }
-                }
-            }))
-
-            setBrowsePaginationByProvider(previous => {
-                const next = { ...previous }
-
-                for (const { providerName, result } of results) {
-                    next[providerName] = {
-                        loaded: true,
-                        nextPage: result?.nextPage ?? null,
-                        totalCount: result?.totalCount ?? previous[providerName]?.totalCount ?? 0,
-                        pageSize: previous[providerName]?.pageSize ?? DEFAULT_BROWSE_PAGE_SIZE,
-                        isLoading: false,
-                    }
-                }
-
-                return next
-            })
-        } finally {
-            loadMoreInFlightRef.current = false
-        }
-    }, [])
-
-    useEffect(() => {
-        if (!loadMoreTriggerRef.current) return;
-        const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting && anyProviderHasMore && !anyProviderLoadingMore) {
-                void loadMore()
-            }
-        }, { threshold: 0.1, rootMargin: '100px' });
-        observer.observe(loadMoreTriggerRef.current);
-        return () => observer.disconnect();
-    }, [anyProviderHasMore, anyProviderLoadingMore, loadMore, selectedConnector, selectedMultiChainConnector]);
-
-    useEffect(() => {
-        if (providersSettled) return
-        const timer = setTimeout(() => setSettleTimedOut(true), PROVIDER_SETTLE_TIMEOUT_MS)
-        return () => clearTimeout(timer)
-    }, [providersSettled])
-
-    if (!providersSettled && !settleTimedOut) {
+    if (showProvidersLoading) {
         return (
             <div className="flex h-full min-h-80 w-full items-center justify-center py-10">
                 <div className="loader text-[3px]!" />
             </div>
-        )
+        );
     }
 
-    if (selectedConnector?.extensionNotFound && !selectedConnector?.showQrCode && !isMobilePlatfrom) {
-        const provider = featuredProviders.find(p => p.name === selectedConnector?.providerName)
-        if (!provider) return null
-        return <InstalledExtensionNotFound selectedConnector={selectedConnector} onConnect={(connector) => { connect(connector, provider) }} />
+    if (
+        selectedConnector?.extensionNotFound &&
+        !selectedConnector.showQrCode &&
+        !isMobilePlatform
+    ) {
+        const provider = featuredProviders.find(
+            (candidate) => candidate.name === selectedConnector.providerName,
+        );
+        if (!provider) return null;
+        return (
+            <InstalledExtensionNotFound
+                selectedConnector={selectedConnector}
+                onConnect={(connector) => {
+                    void connect(connector, provider);
+                }}
+            />
+        );
     }
-    if (selectedConnector?.qr?.state && (!selectedConnector?.hasBrowserExtension || selectedConnector?.showQrCode)) {
-        return <WalletQrCode selectedConnector={selectedConnector} />
+
+    if (
+        selectedConnector?.qr?.state &&
+        (!selectedConnector.hasBrowserExtension || selectedConnector.showQrCode)
+    ) {
+        return <WalletQrCode selectedConnector={selectedConnector} />;
     }
 
     if (selectedConnector) {
-        const provider = featuredProviders.find(p => p.name === selectedConnector?.providerName)
-        return <LoadingConnect
-            onRetry={() => { (selectedConnector && provider) && connect(selectedConnector, provider) }}
-            selectedConnector={selectedConnector}
-            connectionError={connectionError}
-        />
+        const provider = featuredProviders.find(
+            (candidate) => candidate.name === selectedConnector.providerName,
+        );
+        return (
+            <LoadingConnect
+                onRetry={() => {
+                    if (provider) void connect(selectedConnector, provider);
+                }}
+                selectedConnector={selectedConnector}
+                connectionError={connectionError}
+            />
+        );
     }
 
     if (currentMultiChainConnector) {
-        return <MultichainConnectorPicker
-            selectedConnector={currentMultiChainConnector}
-            providers={featuredProviders}
-            connect={connect}
-        />
+        return (
+            <MultichainConnectorPicker
+                selectedConnector={currentMultiChainConnector}
+                providers={featuredProviders}
+                connect={connect}
+            />
+        );
     }
 
     return (
-        <>
-            <div className="text-primary-text space-y-3 flex flex-col w-full styled-scroll relative h-full">
-                <div className="flex items-center gap-3 pt-1">
-                    <SearchComponent
-                        searchQuery={searchValue || ""}
-                        setSearchQuery={setSearchValue}
-                        placeholder="Search through 500+ wallets..."
-                        containerClassName="w-full mb-0!"
-                    />
-                    {
-                        (!selectedProvider || selectedProvider?.isSelectedFromFilter) &&
-                        <ProviderPicker
-                            providers={filteredProviders}
-                            selectedProviderNames={selectedProviderNames}
-                            setSelectedProviderNames={handleSelectProvider}
-                        />
-                    }
-                </div>
-                <div
-                    onScroll={handleScroll}
-                    className={clsx('overflow-y-scroll -mr-4 pr-2 scrollbar:!w-1.5 scrollbar:!h-1.5 overflow-x-hidden scrollbar-thumb:bg-transparent', {
-                        'h-[calc(100svh-160px)]': isMobileSize && AppSettings.ThemeData?.enablePortal,
-                        'styled-scroll': isScrolling
-                    })}
-                >
-                    <div className='grid grid-cols-2 gap-2'>
-                        {
-                            initialConnectors.map(item => {
-                                const provider = featuredProviders.find(p => p.name === item.providerName)
-                                const isRecent = item.isRecent
-                                return (
-                                    <Connector
-                                        key={item.id}
-                                        connector={item}
-                                        onClick={() => provider && connect(item, provider)}
-                                        connectingConnector={selectedConnector}
-                                        isRecent={isRecent}
-                                        isProviderReady={isProviderConnectReady(provider)}
-                                    />
-                                )
-                            })
-                        }
-                    </div>
-                    {(anyProviderHasMore || anyProviderLoadingMore) && (
-                        <div ref={loadMoreTriggerRef} className="col-span-2 flex justify-center items-center pt-2.5">
-                            <CircularLoader className="w-8 h-8 animate-spin" />
-                        </div>
-                    )}
-                </div>
-            </div>
-        </>
-    )
-}
+        <ConnectorsGrid
+            connectors={initialConnectors}
+            featuredProviders={featuredProviders}
+            filteredProviders={filteredProviders}
+            hasMore={hasMore}
+            isLoadingMore={isLoadingMore}
+            loadMore={loadMore}
+            onConnect={(connector, provider) => {
+                void connect(connector, provider);
+            }}
+            onSelectProviders={selectProviders}
+            searchValue={searchValue}
+            selectedConnector={selectedConnector}
+            selectedProvider={selectedProvider}
+            selectedProviderNames={selectedProviderNames}
+            setSearchValue={setSearchValue}
+        />
+    );
+};
 
-
-export default ConnectorsList
+export default ConnectorsList;

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/connectorPagination.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/connectorPagination.ts
@@ -1,0 +1,59 @@
+import type {
+    InternalConnector,
+    WalletConnectionProvider,
+} from "@/types/wallet";
+
+export type ProviderPaginationState = {
+    loaded: boolean;
+    nextPage: number | null;
+    totalCount: number;
+    pageSize: number;
+    isLoading: boolean;
+};
+
+export type RequestCapableWalletProvider = WalletConnectionProvider & {
+    requestAdditionalConnectors: NonNullable<
+        WalletConnectionProvider["requestAdditionalConnectors"]
+    >;
+};
+
+export const DEFAULT_BROWSE_PAGE_SIZE = 40;
+export const SEARCH_PAGE_SIZE = 100;
+
+export const canRequestAdditionalConnectors = (
+    provider: WalletConnectionProvider,
+): provider is RequestCapableWalletProvider =>
+    typeof provider.requestAdditionalConnectors === "function";
+
+export const requestCapableProviderNamesKey = (
+    providers: WalletConnectionProvider[],
+) =>
+    providers
+        .filter(canRequestAdditionalConnectors)
+        .map((provider) => provider.name)
+        .join("|");
+
+export const upsertLoadingState = (
+    previous: Record<string, ProviderPaginationState>,
+    providerNames: string[],
+    pageSize: number,
+) => {
+    const next = { ...previous };
+
+    for (const providerName of providerNames) {
+        next[providerName] = {
+            loaded: previous[providerName]?.loaded ?? false,
+            nextPage: previous[providerName]?.nextPage ?? null,
+            totalCount: previous[providerName]?.totalCount ?? 0,
+            pageSize: previous[providerName]?.pageSize ?? pageSize,
+            isLoading: true,
+        };
+    }
+
+    return next;
+};
+
+export const withProviderName = (
+    providerName: string,
+    connectors: InternalConnector[],
+) => connectors.map((connector) => ({ ...connector, providerName }));

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useBrowseConnectors.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useBrowseConnectors.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { WalletConnectionProvider } from "@/types/wallet";
+import {
+    DEFAULT_BROWSE_PAGE_SIZE,
+    type ProviderPaginationState,
+    requestCapableProviderNamesKey,
+    upsertLoadingState,
+} from "./connectorPagination";
+
+export function useBrowseConnectors(
+    featuredProviders: WalletConnectionProvider[],
+    isSearching: boolean,
+) {
+    const [pagination, setPagination] = useState<
+        Record<string, ProviderPaginationState>
+    >({});
+    const featuredProvidersRef = useRef(featuredProviders);
+    const paginationRef = useRef(pagination);
+    const loadMoreInFlightRef = useRef(false);
+
+    featuredProvidersRef.current = featuredProviders;
+    paginationRef.current = pagination;
+
+    const providerNamesKey = requestCapableProviderNamesKey(featuredProviders);
+
+    // Load the first browse page for each registry-backed provider.
+    useEffect(() => {
+        if (isSearching) return;
+
+        let cancelled = false;
+        const providersToLoad = featuredProvidersRef.current.filter(
+            (provider) =>
+                provider.requestAdditionalConnectors &&
+                !paginationRef.current[provider.name]?.loaded &&
+                !paginationRef.current[provider.name]?.isLoading,
+        );
+
+        if (providersToLoad.length === 0) return;
+
+        setPagination((previous) =>
+            upsertLoadingState(
+                previous,
+                providersToLoad.map((provider) => provider.name),
+                DEFAULT_BROWSE_PAGE_SIZE,
+            ),
+        );
+
+        Promise.all(
+            providersToLoad.map(async (provider) => {
+                try {
+                    const result = await provider.requestAdditionalConnectors?.(
+                        {
+                            page: 1,
+                            pageSize: DEFAULT_BROWSE_PAGE_SIZE,
+                        },
+                    );
+                    return { providerName: provider.name, result };
+                } catch {
+                    return { providerName: provider.name, result: undefined };
+                }
+            }),
+        ).then((results) => {
+            if (cancelled) return;
+
+            setPagination((previous) => {
+                const next = { ...previous };
+                for (const { providerName, result } of results) {
+                    next[providerName] = {
+                        loaded: true,
+                        nextPage: result?.nextPage ?? null,
+                        totalCount: result?.totalCount ?? 0,
+                        pageSize:
+                            previous[providerName]?.pageSize ??
+                            DEFAULT_BROWSE_PAGE_SIZE,
+                        isLoading: false,
+                    };
+                }
+                return next;
+            });
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [isSearching, providerNamesKey]);
+
+    const loadMore = useCallback(async () => {
+        if (loadMoreInFlightRef.current) return;
+        loadMoreInFlightRef.current = true;
+
+        try {
+            const providersToLoad = featuredProvidersRef.current.filter(
+                (provider) => {
+                    const state = paginationRef.current[provider.name];
+                    return (
+                        provider.requestAdditionalConnectors &&
+                        state?.nextPage != null &&
+                        !state.isLoading
+                    );
+                },
+            );
+
+            if (providersToLoad.length === 0) return;
+
+            setPagination((previous) =>
+                upsertLoadingState(
+                    previous,
+                    providersToLoad.map((provider) => provider.name),
+                    DEFAULT_BROWSE_PAGE_SIZE,
+                ),
+            );
+
+            const results = await Promise.all(
+                providersToLoad.map(async (provider) => {
+                    const state = paginationRef.current[provider.name];
+                    try {
+                        const result =
+                            await provider.requestAdditionalConnectors?.({
+                                page: state?.nextPage ?? 1,
+                                pageSize:
+                                    state?.pageSize ?? DEFAULT_BROWSE_PAGE_SIZE,
+                            });
+                        return { providerName: provider.name, result };
+                    } catch {
+                        return {
+                            providerName: provider.name,
+                            result: undefined,
+                        };
+                    }
+                }),
+            );
+
+            setPagination((previous) => {
+                const next = { ...previous };
+                for (const { providerName, result } of results) {
+                    next[providerName] = {
+                        loaded: true,
+                        nextPage: result?.nextPage ?? null,
+                        totalCount:
+                            result?.totalCount ??
+                            previous[providerName]?.totalCount ??
+                            0,
+                        pageSize:
+                            previous[providerName]?.pageSize ??
+                            DEFAULT_BROWSE_PAGE_SIZE,
+                        isLoading: false,
+                    };
+                }
+                return next;
+            });
+        } finally {
+            loadMoreInFlightRef.current = false;
+        }
+    }, []);
+
+    return {
+        hasMore: featuredProviders.some(
+            (provider) => pagination[provider.name]?.nextPage != null,
+        ),
+        isLoading: featuredProviders.some(
+            (provider) => pagination[provider.name]?.isLoading,
+        ),
+        loadMore,
+    };
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorConnection.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorConnection.ts
@@ -1,0 +1,183 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type {
+    Wallet,
+    WalletConnectionProvider,
+    WalletModalConnector,
+} from "@/types/wallet";
+import { connectorKey } from "@/hooks/useConnectors";
+import { isMobile } from "@/lib/wallets/utils/isMobile";
+import { useConnectModal } from "..";
+import { useWalletProviderResolution } from "./useWalletProviderResolution";
+
+type UseConnectorConnectionParams = {
+    featuredProviders: WalletConnectionProvider[];
+    initialConnectors: WalletModalConnector[];
+    onFinish: (result: Wallet | undefined) => void;
+    rememberConnector: (providerName: string, connectorName: string) => void;
+};
+
+export function useConnectorConnection({
+    featuredProviders,
+    initialConnectors,
+    onFinish,
+    rememberConnector,
+}: UseConnectorConnectionParams) {
+    const {
+        selectedConnector,
+        selectedMultiChainConnector,
+        setSelectedConnector,
+        setSelectedMultiChainConnector,
+    } = useConnectModal();
+    const {
+        awaitLiveProvider,
+        awaitProvidersSettled,
+        liveVariantCount,
+        providersAreSettled,
+    } = useWalletProviderResolution(featuredProviders);
+    const [connectionError, setConnectionError] = useState<string>();
+    const initialConnectorsRef = useRef(initialConnectors);
+    const isMobilePlatform = isMobile();
+
+    initialConnectorsRef.current = initialConnectors;
+
+    const connect = useCallback(
+        async (
+            connector: WalletModalConnector,
+            provider: WalletConnectionProvider,
+        ) => {
+            try {
+                setConnectionError(undefined);
+
+                // The ecosystem picker passes a concrete variant. Resolving that
+                // variant back to the top-level tile would reopen the picker.
+                const isEcosystemSelection =
+                    selectedMultiChainConnector !== undefined;
+                const providersStillLoading = !providersAreSettled();
+                const shouldWaitForVariants =
+                    !isEcosystemSelection &&
+                    providersStillLoading &&
+                    (connector.type === "injected" || connector.isMultiChain);
+
+                if (shouldWaitForVariants && !(await awaitProvidersSettled())) {
+                    setConnectionError(
+                        "Wallet providers are still initializing. Please wait a moment and try again.",
+                    );
+                    return;
+                }
+
+                const latestConnector = isEcosystemSelection
+                    ? connector
+                    : (initialConnectorsRef.current.find(
+                          (current) =>
+                              connectorKey(current.name) ===
+                              connectorKey(connector.name),
+                      ) ?? connector);
+
+                if (
+                    !isEcosystemSelection &&
+                    (latestConnector.isMultiChain ||
+                        liveVariantCount(connector.name) > 1)
+                ) {
+                    setSelectedConnector(undefined);
+                    setSelectedMultiChainConnector(latestConnector);
+                    return;
+                }
+
+                setSelectedConnector(latestConnector);
+                if (
+                    latestConnector.hasBrowserExtension !== false &&
+                    latestConnector.extensionNotFound &&
+                    !latestConnector.showQrCode &&
+                    !isMobilePlatform
+                ) {
+                    return;
+                }
+
+                let liveProvider = provider;
+                if (provider.isStub) {
+                    liveProvider =
+                        (await awaitLiveProvider(provider.id)) ?? provider;
+                }
+                if (liveProvider.isStub || !liveProvider.ready) {
+                    setConnectionError(
+                        "Wallet provider is still initializing. Please wait a moment and try again.",
+                    );
+                    return;
+                }
+
+                const result = await liveProvider.connectWallet?.({
+                    connector: latestConnector,
+                });
+                if (!result) {
+                    setConnectionError(
+                        "Connection didn't complete. Please try again.",
+                    );
+                    return;
+                }
+
+                rememberConnector(provider.name, latestConnector.name);
+                onFinish(result);
+                setSelectedConnector(undefined);
+            } catch (error) {
+                console.log(error);
+                const walletError = error as {
+                    name?: string;
+                    message?: string;
+                    details?: string;
+                };
+                const message = (
+                    walletError.message ||
+                    walletError.details ||
+                    ""
+                ).toLowerCase();
+                if (
+                    walletError.name === "WalletWindowClosedError" ||
+                    message.includes("rejected") ||
+                    message.includes("denied")
+                ) {
+                    setConnectionError(
+                        "You've declined the wallet connection request",
+                    );
+                } else {
+                    setConnectionError(
+                        walletError.message ||
+                            walletError.details ||
+                            "Something went wrong",
+                    );
+                }
+            }
+        },
+        [
+            awaitLiveProvider,
+            awaitProvidersSettled,
+            isMobilePlatform,
+            liveVariantCount,
+            onFinish,
+            providersAreSettled,
+            rememberConnector,
+            selectedMultiChainConnector,
+            setSelectedConnector,
+            setSelectedMultiChainConnector,
+        ],
+    );
+
+    // Always resolve the selected wallet against the latest derived list so
+    // variants published after the click replace the old connector snapshot.
+    const currentMultiChainConnector = useMemo(() => {
+        if (!selectedMultiChainConnector) return undefined;
+        return (
+            initialConnectors.find(
+                (connector) =>
+                    connectorKey(connector.name) ===
+                    connectorKey(selectedMultiChainConnector.name),
+            ) ?? selectedMultiChainConnector
+        );
+    }, [initialConnectors, selectedMultiChainConnector]);
+
+    return {
+        connect,
+        connectionError,
+        currentMultiChainConnector,
+        selectedConnector,
+    };
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorPagination.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorPagination.ts
@@ -1,0 +1,20 @@
+import type { WalletConnectionProvider } from "@/types/wallet";
+import { useBrowseConnectors } from "./useBrowseConnectors";
+import { useConnectorSearch } from "./useConnectorSearch";
+
+export function useConnectorPagination(
+    featuredProviders: WalletConnectionProvider[],
+) {
+    const search = useConnectorSearch(featuredProviders);
+    const browse = useBrowseConnectors(featuredProviders, search.isSearching);
+    const activePagination = search.isSearching ? search : browse;
+
+    return {
+        hasMore: activePagination.hasMore,
+        isLoadingMore: activePagination.isLoading,
+        loadMore: activePagination.loadMore,
+        searchResults: search.searchResults,
+        searchValue: search.searchValue,
+        setSearchValue: search.setSearchValue,
+    };
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorProviders.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorProviders.ts
@@ -1,0 +1,71 @@
+import { useCallback, useMemo, useState } from "react";
+import type { WalletConnectionProvider } from "@/types/wallet";
+import { useConnectModal } from "..";
+
+export function useConnectorProviders(providers: WalletConnectionProvider[]) {
+    const { selectedProvider, setSelectedProvider } = useConnectModal();
+    const [selectedProviderNames, setSelectedProviderNames] = useState<
+        string[]
+    >([]);
+
+    // Keep these arrays stable across unrelated modal renders. They feed the
+    // connector resolution pipeline, which is intentionally memoized.
+    const filteredProviders = useMemo(
+        () => providers.filter((provider) => !provider.hideFromList),
+        [providers],
+    );
+
+    // A selected provider is a snapshot captured when connect() opens the
+    // modal. Re-resolve it against the live list so late connector updates are
+    // visible. Hidden scoped providers (for example Paradex) must remain valid.
+    const resolvedSelectedProvider = useMemo(
+        () =>
+            selectedProvider && !selectedProvider.isSelectedFromFilter
+                ? providers.find(
+                      (provider) => provider.name === selectedProvider.name,
+                  ) || selectedProvider
+                : selectedProvider,
+        [providers, selectedProvider],
+    );
+
+    const featuredProviders = useMemo(() => {
+        if (selectedProviderNames.length > 0) {
+            return filteredProviders.filter((provider) =>
+                selectedProviderNames.includes(provider.name),
+            );
+        }
+        return resolvedSelectedProvider
+            ? [resolvedSelectedProvider]
+            : filteredProviders;
+    }, [filteredProviders, resolvedSelectedProvider, selectedProviderNames]);
+
+    const selectProviders = useCallback(
+        (providerNames: string[]) => {
+            setSelectedProviderNames(providerNames);
+
+            if (providerNames.length === 0) {
+                setSelectedProvider(undefined);
+                return;
+            }
+
+            const provider = filteredProviders.find(
+                (candidate) => candidate.name === providerNames[0],
+            );
+            if (provider) {
+                setSelectedProvider({
+                    ...provider,
+                    isSelectedFromFilter: true,
+                });
+            }
+        },
+        [filteredProviders, setSelectedProvider],
+    );
+
+    return {
+        featuredProviders,
+        filteredProviders,
+        selectedProvider,
+        selectedProviderNames,
+        selectProviders,
+    };
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorSearch.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useConnectorSearch.ts
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+    InternalConnector,
+    WalletConnectionProvider,
+} from "@/types/wallet";
+import {
+    canRequestAdditionalConnectors,
+    type ProviderPaginationState,
+    requestCapableProviderNamesKey,
+    SEARCH_PAGE_SIZE,
+    upsertLoadingState,
+    withProviderName,
+} from "./connectorPagination";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const clearResultsIfNeeded = (previous: InternalConnector[]) =>
+    previous.length === 0 ? previous : [];
+
+const clearPaginationIfNeeded = (
+    previous: Record<string, ProviderPaginationState>,
+) => (Object.keys(previous).length === 0 ? previous : {});
+
+export function useConnectorSearch(
+    featuredProviders: WalletConnectionProvider[],
+) {
+    const [searchValue, setSearchValue] = useState<string | undefined>();
+    const [results, setResults] = useState<InternalConnector[]>([]);
+    const [pagination, setPagination] = useState<
+        Record<string, ProviderPaginationState>
+    >({});
+    const featuredProvidersRef = useRef(featuredProviders);
+    const paginationRef = useRef(pagination);
+    const currentSearchValue = searchValue?.trim() ?? "";
+    const currentSearchValueRef = useRef(currentSearchValue);
+    const requestSequenceRef = useRef(0);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const loadMoreInFlightRef = useRef(false);
+    const isSearching = currentSearchValue.length >= 2;
+
+    featuredProvidersRef.current = featuredProviders;
+    paginationRef.current = pagination;
+    currentSearchValueRef.current = currentSearchValue;
+
+    const providerNamesKey = requestCapableProviderNamesKey(featuredProviders);
+
+    // Debounce remote wallet-registry search and discard stale responses.
+    useEffect(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+
+        if (!isSearching) {
+            requestSequenceRef.current += 1;
+            setResults(clearResultsIfNeeded);
+            setPagination(clearPaginationIfNeeded);
+            return;
+        }
+
+        const requestId = requestSequenceRef.current + 1;
+        requestSequenceRef.current = requestId;
+        const searchableProviders = featuredProvidersRef.current.filter(
+            canRequestAdditionalConnectors,
+        );
+
+        if (searchableProviders.length === 0) {
+            setResults(clearResultsIfNeeded);
+            setPagination(clearPaginationIfNeeded);
+            return;
+        }
+
+        setPagination((previous) =>
+            upsertLoadingState(
+                previous,
+                searchableProviders.map((provider) => provider.name),
+                SEARCH_PAGE_SIZE,
+            ),
+        );
+
+        debounceRef.current = setTimeout(async () => {
+            const query = currentSearchValueRef.current;
+            const searchResults = await Promise.all(
+                searchableProviders.map(async (provider) => {
+                    try {
+                        const result =
+                            await provider.requestAdditionalConnectors({
+                                page: 1,
+                                pageSize: SEARCH_PAGE_SIZE,
+                                query,
+                            });
+                        return { providerName: provider.name, result };
+                    } catch {
+                        return {
+                            providerName: provider.name,
+                            result: undefined,
+                        };
+                    }
+                }),
+            );
+
+            if (
+                requestId !== requestSequenceRef.current ||
+                query !== currentSearchValueRef.current
+            ) {
+                return;
+            }
+
+            setResults(
+                searchResults.flatMap(({ providerName, result }) =>
+                    withProviderName(providerName, result?.connectors ?? []),
+                ),
+            );
+            setPagination((previous) => {
+                const next = { ...previous };
+                for (const { providerName, result } of searchResults) {
+                    next[providerName] = {
+                        loaded: true,
+                        nextPage: result?.nextPage ?? null,
+                        totalCount: result?.totalCount ?? 0,
+                        pageSize: SEARCH_PAGE_SIZE,
+                        isLoading: false,
+                    };
+                }
+                return next;
+            });
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+        };
+    }, [currentSearchValue, isSearching, providerNamesKey]);
+
+    const loadMore = useCallback(async () => {
+        if (loadMoreInFlightRef.current) return;
+        loadMoreInFlightRef.current = true;
+
+        try {
+            const query = currentSearchValueRef.current;
+            const requestId = requestSequenceRef.current;
+            const providersToLoad = featuredProvidersRef.current.filter(
+                (provider) => {
+                    const state = paginationRef.current[provider.name];
+                    return (
+                        provider.requestAdditionalConnectors &&
+                        state?.nextPage != null &&
+                        !state.isLoading
+                    );
+                },
+            );
+
+            if (providersToLoad.length === 0) return;
+
+            setPagination((previous) =>
+                upsertLoadingState(
+                    previous,
+                    providersToLoad.map((provider) => provider.name),
+                    SEARCH_PAGE_SIZE,
+                ),
+            );
+
+            const searchResults = await Promise.all(
+                providersToLoad.map(async (provider) => {
+                    const state = paginationRef.current[provider.name];
+                    try {
+                        const result =
+                            await provider.requestAdditionalConnectors?.({
+                                page: state?.nextPage ?? 1,
+                                pageSize: state?.pageSize ?? SEARCH_PAGE_SIZE,
+                                query,
+                            });
+                        return { providerName: provider.name, result };
+                    } catch {
+                        return {
+                            providerName: provider.name,
+                            result: undefined,
+                        };
+                    }
+                }),
+            );
+
+            if (
+                requestId !== requestSequenceRef.current ||
+                query !== currentSearchValueRef.current
+            ) {
+                return;
+            }
+
+            setResults((previous) => [
+                ...previous,
+                ...searchResults.flatMap(({ providerName, result }) =>
+                    withProviderName(providerName, result?.connectors ?? []),
+                ),
+            ]);
+            setPagination((previous) => {
+                const next = { ...previous };
+                for (const { providerName, result } of searchResults) {
+                    next[providerName] = {
+                        loaded: true,
+                        nextPage: result?.nextPage ?? null,
+                        totalCount:
+                            result?.totalCount ??
+                            previous[providerName]?.totalCount ??
+                            0,
+                        pageSize:
+                            previous[providerName]?.pageSize ??
+                            SEARCH_PAGE_SIZE,
+                        isLoading: false,
+                    };
+                }
+                return next;
+            });
+        } finally {
+            loadMoreInFlightRef.current = false;
+        }
+    }, []);
+
+    return {
+        hasMore: featuredProviders.some(
+            (provider) => pagination[provider.name]?.nextPage != null,
+        ),
+        isLoading: featuredProviders.some(
+            (provider) => pagination[provider.name]?.isLoading,
+        ),
+        isSearching,
+        loadMore,
+        searchResults: isSearching ? results : undefined,
+        searchValue,
+        setSearchValue,
+    };
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useProviderLoadingGate.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useProviderLoadingGate.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+const PROVIDER_SETTLE_TIMEOUT_MS = 5000;
+
+/**
+ * Keep the connector grid hidden while providers initialize, but preserve the
+ * existing bounded fallback so one failed provider cannot block the modal
+ * forever.
+ */
+export function useProviderLoadingGate(providersSettled: boolean): boolean {
+    const [settleTimedOut, setSettleTimedOut] = useState(false);
+
+    useEffect(() => {
+        if (providersSettled) return;
+        const timer = setTimeout(
+            () => setSettleTimedOut(true),
+            PROVIDER_SETTLE_TIMEOUT_MS,
+        );
+        return () => clearTimeout(timer);
+    }, [providersSettled]);
+
+    return !providersSettled && !settleTimedOut;
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useRecentConnectors.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useRecentConnectors.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+import { usePersistedState } from "@/hooks/usePersistedState";
+
+export type RecentConnector = {
+    providerName?: string;
+    connectorName?: string;
+};
+
+export function useRecentConnectors() {
+    const [recentConnectors, setRecentConnectors] = usePersistedState<
+        RecentConnector[]
+    >([], "recentConnectors", "localStorage");
+
+    const rememberConnector = useCallback(
+        (providerName: string, connectorName: string) => {
+            setRecentConnectors((previous) => {
+                const next: RecentConnector[] = [
+                    { providerName, connectorName },
+                ];
+                const counts = new Map<string, number>([[providerName, 1]]);
+
+                for (const item of previous || []) {
+                    if (
+                        !item.providerName ||
+                        !item.connectorName ||
+                        (item.providerName === providerName &&
+                            item.connectorName === connectorName)
+                    ) {
+                        continue;
+                    }
+
+                    const count = counts.get(item.providerName) ?? 0;
+                    if (count < 3) {
+                        next.push(item);
+                        counts.set(item.providerName, count + 1);
+                    }
+                }
+                return next;
+            });
+        },
+        [setRecentConnectors],
+    );
+
+    return { recentConnectors, rememberConnector };
+}

--- a/packages/widget/core/src/components/Wallet/WalletModal/hooks/useWalletProviderResolution.ts
+++ b/packages/widget/core/src/components/Wallet/WalletModal/hooks/useWalletProviderResolution.ts
@@ -1,0 +1,106 @@
+import { useCallback, useRef } from "react";
+import type { WalletConnectionProvider } from "@/types/wallet";
+import { connectorKey } from "@/hooks/useConnectors";
+import {
+    areWalletProvidersSettled,
+    useWalletProvidersRegistry,
+} from "@/context/walletProviders";
+import { useWalletDescriptorLoader } from "@/lib/walletConnect/walletDescriptorLoader";
+
+const PROVIDER_SETTLE_TIMEOUT_MS = 5000;
+
+export function useWalletProviderResolution(
+    featuredProviders: WalletConnectionProvider[],
+) {
+    const registry = useWalletProvidersRegistry();
+    const { loadAll, loadById } = useWalletDescriptorLoader();
+    const featuredProvidersRef = useRef(featuredProviders);
+    featuredProvidersRef.current = featuredProviders;
+
+    const providersAreSettled = useCallback(
+        () => areWalletProvidersSettled(registry),
+        [registry],
+    );
+
+    const liveVariantCount = useCallback(
+        (name: string) => {
+            const key = connectorKey(name);
+            const featuredProviderIds = new Set(
+                featuredProvidersRef.current.map((provider) => provider.id),
+            );
+
+            return registry.getEntries().filter((entry) => {
+                if (!featuredProviderIds.has(entry.id)) return false;
+                const state = entry.store.getState();
+                return [
+                    ...(state.availableConnectors ?? []),
+                    ...(state.additionalConnectors ?? []),
+                ].some((candidate) => connectorKey(candidate.name) === key);
+            }).length;
+        },
+        [registry],
+    );
+
+    const awaitProvidersSettled = useCallback(
+        async (timeoutMs = PROVIDER_SETTLE_TIMEOUT_MS): Promise<boolean> => {
+            await loadAll();
+            const settled = () => areWalletProvidersSettled(registry);
+            if (settled()) return true;
+
+            return new Promise<boolean>((resolve) => {
+                let unsubscribe = () => {};
+                const finish = (didSettle: boolean) => {
+                    clearTimeout(timer);
+                    unsubscribe();
+                    resolve(didSettle);
+                };
+                const timer = setTimeout(() => finish(false), timeoutMs);
+                unsubscribe = registry.subscribe(() => {
+                    if (settled()) finish(true);
+                });
+            });
+        },
+        [loadAll, registry],
+    );
+
+    const awaitLiveProvider = useCallback(
+        async (
+            providerId: string,
+            timeoutMs = PROVIDER_SETTLE_TIMEOUT_MS,
+        ): Promise<WalletConnectionProvider | undefined> => {
+            void loadById(providerId);
+            const getLiveProvider = () => {
+                const state = registry
+                    .getEntries()
+                    .find((entry) => entry.id === providerId)
+                    ?.store.getState();
+                return state && !state.isStub && state.ready
+                    ? state
+                    : undefined;
+            };
+            const current = getLiveProvider();
+            if (current) return current;
+
+            return new Promise((resolve) => {
+                let unsubscribe = () => {};
+                const finish = () => {
+                    clearTimeout(timer);
+                    unsubscribe();
+                    resolve(getLiveProvider());
+                };
+                const timer = setTimeout(finish, timeoutMs);
+                unsubscribe = registry.subscribe(() => {
+                    if (getLiveProvider()) finish();
+                });
+            });
+        },
+        [loadById, registry],
+    );
+
+    return {
+        awaitLiveProvider,
+        awaitProvidersSettled,
+        liveVariantCount,
+        providersAreSettled,
+    };
+}

--- a/packages/widget/core/src/context/walletProviders.tsx
+++ b/packages/widget/core/src/context/walletProviders.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { createContext, lazy, Suspense, useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, { createContext, lazy, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { StoreApi } from "zustand/vanilla";
 import { WalletConnectionProvider, WalletConnectionStore, WalletProvider, WalletProviderDescriptor, WalletWrapper, isWalletProviderDescriptor } from "@/types";
 import { useSettingsState } from "./settings";
@@ -39,6 +39,27 @@ const WalletProvidersReadyContext = createContext<boolean>(false)
 
 export function useWalletProvidersReady(): boolean {
     return useContext(WalletProvidersReadyContext)
+}
+
+/** Synchronous check: true when every provider is a ready, non-stub live provider. */
+export function areWalletProvidersSettled(registry: WalletProvidersRegistry): boolean {
+    return registry.getEntries().every(entry => {
+        const provider = entry.store.getState()
+        return !provider.isStub && provider.ready
+    })
+}
+
+/**
+ * React subscription hook. True only after the provider registry has been
+ * published and every descriptor has been replaced by a ready live provider.
+ */
+export function useWalletProvidersSettled(): boolean {
+    const registryInitialized = useWalletProvidersReady()
+    const registry = useWalletProvidersRegistry()
+    const getSnapshot = useCallback(() => areWalletProvidersSettled(registry), [registry])
+    const providersSettled = useSyncExternalStore(registry.subscribe, getSnapshot, () => false)
+
+    return registryInitialized && providersSettled
 }
 
 type ProviderEntry = WalletProvider | WalletWrapper | WalletProviderDescriptor

--- a/packages/widget/core/src/hooks/useConnectors.ts
+++ b/packages/widget/core/src/hooks/useConnectors.ts
@@ -21,7 +21,7 @@ type InitialSnapshot = {
 
 const UNMERGEABLE_WALLETS = ['nova', 'nova wallet']
 const NAME_OVERRIDES: Record<string, string> = { bitget: 'Bitget Wallet' }
-const connectorKey = (name: string) =>
+export const connectorKey = (name: string) =>
     UNMERGEABLE_WALLETS.includes(name.toLowerCase()) ? name.toLowerCase() : walletKey(name)
 
 const resolveNames = (groups: InternalConnector[][]): InternalConnector[][] => {


### PR DESCRIPTION
## Summary
- wait for wallet providers before rendering the connector list so multichain choices are complete
- refresh late provider variants and keep provider hydration bounded
- split ConnectorsList into focused connection, provider, search, pagination, persistence, and presentation modules

## Validation
- pnpm --filter @layerswap/widget check:types
- pnpm --filter @layerswap/widget build:esm+types