### PR TITLE
fix(bridge): pin API base endpoint and tolerate fetch failures in swap page SSR

### DIFF
--- a/apps/bridge/pages/swap/[swapId].tsx
+++ b/apps/bridge/pages/swap/[swapId].tsx
@@ -2,7 +2,7 @@ import { InferGetServerSidePropsType } from 'next';
 import React, { useMemo } from 'react';
 import { getThemeData } from '../../helpers/settingsHelper';
 import { SwapWithdrawal, inflateSettings, encodeSettingsForSSR } from '@layerswap/widget';
-import { LayerswapApiClient } from '@layerswap/widget/internal';
+import { AppSettings, LayerswapApiClient } from '@layerswap/widget/internal';
 import Layout from '../../components/layout';
 import { useRouter } from 'next/router';
 import { resolvePersistantQueryParams } from '../../helpers/querryHelper';
@@ -54,10 +54,19 @@ export const getServerSideProps = async (ctx) => {
   const app = ctx.query?.appName || ctx.query?.addressSource
   const apiKey = JSON.parse(process.env.API_KEYS || "{ }")?.[app] || process.env.NEXT_PUBLIC_API_KEY
   LayerswapApiClient.apiKey = apiKey
+  LayerswapApiClient.apiBaseEndpoint = process.env.NEXT_PUBLIC_LS_API || AppSettings.LayerswapApiUri
   const apiClient = new LayerswapApiClient()
-  const { data: networkData } = await apiClient.GetLSNetworksAsync()
 
-  const { data: swapData } = await apiClient.GetSwapAsync(params.swapId)
+  const [networkData, swapData] = await Promise.all([
+    apiClient.GetLSNetworksAsync().then(res => res.data).catch(error => {
+      console.error('[swap/[swapId]] Failed to fetch networks', error)
+      return undefined
+    }),
+    apiClient.GetSwapAsync(params.swapId).then(res => res.data).catch(error => {
+      console.error('[swap/[swapId]] Failed to fetch swap', error)
+      return undefined
+    }),
+  ])
 
   if (swapData?.swap.transactions.length == 0) {
     const redirectParams = new URLSearchParams({
@@ -79,12 +88,10 @@ export const getServerSideProps = async (ctx) => {
     }
   }
 
-  if (!networkData) return
-
-  const settings = {
+  const settings = networkData ? {
     networks: networkData,
     featureFlags: await resolveExtendedRouteFlags(ctx.req),
-  }
+  } : null
 
   const themeData = await getThemeData(ctx.query)
 


### PR DESCRIPTION

The swap page's getServerSideProps set the API key but never set LayerswapApiClient.apiBaseEndpoint, a process-global static defaulting to the production API. On instances where /swap/[swapId] was the first request (nothing had run helpers/getSettings.ts yet), the environment's key was sent to the production API, which answered 403 API_KEY_FORBIDDEN; the unhandled rejection crashed the function with FUNCTION_INVOCATION_FAILED.

- Pin apiBaseEndpoint from NEXT_PUBLIC_LS_API per-request, matching helpers/getSettings.ts
- Fetch networks and swap in parallel, each failure logged and resolved to undefined; failed settings render the maintenance screen (same null contract as the home page) instead of a 500
- Replace the invalid bare `return` on missing network data with a proper props return