### PR TITLE
fix(wallets): treat stub providers as ready in Paradex readiness

### DIFF
--- a/packages/wallets/paradex/src/service/ParadexConnectionService.ts
+++ b/packages/wallets/paradex/src/service/ParadexConnectionService.ts
@@ -9,6 +9,7 @@ import type {
 } from '@layerswap/widget/types'
 import {
     Address,
+    isProviderConnectReady,
     isWalletConnectRegistryConnector,
     KnownInternalNames,
     sleep,
@@ -134,12 +135,18 @@ export class ParadexConnectionService implements WalletConnectionService<Runtime
         return this.getEvmProvider()?.additionalConnectors ?? []
     }
 
+    /**
+     * Paradex has no connection state of its own — it is ready once both
+     * backing providers are. Readiness must go through
+     * {@link isProviderConnectReady} so descriptor stubs count as ready: a stub
+     * only hydrates when the connect modal opens, so reporting `ready: false`
+     * for one would deadlock every connect affordance gated on
+     * `useProvidersConnectReady` (Paradex is `hideFromList`, so users would see
+     * a permanently disabled button with nothing to click to resolve it).
+     */
     isReady(): boolean {
-        const evmProvider = this.getEvmProvider()
-        const starknetProvider = this.getStarknetProvider()
-        const evmReady = typeof evmProvider?.ready === 'boolean' ? evmProvider.ready : true
-        const starknetReady = typeof starknetProvider?.ready === 'boolean' ? starknetProvider.ready : true
-        return evmReady && starknetReady
+        return isProviderConnectReady(this.getEvmProvider())
+            && isProviderConnectReady(this.getStarknetProvider())
     }
 
     private resolveSingleWallet({

--- a/packages/widget/core/src/exports/internal.ts
+++ b/packages/widget/core/src/exports/internal.ts
@@ -20,6 +20,7 @@ export * from "../components/Pages/Swap/Withdraw/Wallet/Common/actionMessage"
 export { default as ClickTooltip } from "../components/Common/ClickTooltip"
 export { useSelectedAccount, useSelectSwapAccount, useSwapAccounts, useLatestSourceAccount, useNetworkBalance } from "@/context/swapAccounts";
 export { default as useWallet } from "@/hooks/useWallet"
+export { isProviderConnectReady } from "@/hooks/useProvidersConnectReady"
 export * from "../lib/apiClients"
 export * from "../lib/formatUnits"
 // Explicit re-exports (not `export * from "../stores"`): the wildcard meant any


### PR DESCRIPTION
## Problem

On a cold load of the swap form, **"Connect a wallet" renders permanently disabled** — with a valid route, a valid amount and a loaded quote. It only becomes clickable if the user happens to open the wallet picker from the widget header (that button isn't gated on the same hook).

## Root cause

`ParadexConnectionService.isReady()` read the backing providers' `ready` field directly:

```ts
const starknetReady = typeof starknetProvider?.ready === 'boolean' ? starknetProvider.ready : true
```

Starknet mounts as a lazy descriptor stub (`isStub: true`, `ready: false`) until something hydrates it, so Paradex reported `ready: false`. Paradex is not itself a stub, so `useProvidersConnectReady()` — which requires every *non-stub* provider to be ready — stayed `false`, disabling every connect affordance gated on it: the swap form CTA (`SourceWalletPicker`), the route pickers, and the deposit-address form.

Two things make it a deadlock rather than a delay:

- the only thing that hydrates a stub is opening the connect modal, which the disabled button can't do;
- Paradex is `hideFromList`, so the provider holding the gate closed is invisible to the user.

This is precisely the failure mode the docblock on `isProviderConnectReady` warns about — Paradex's own `isReady()` just bypassed that stub-awareness.

## Fix

Route readiness through the canonical `isProviderConnectReady` predicate, which exempts stubs for exactly this reason, and export it from the widget's internal entry so the wallet package and `useProvidersConnectReady` share one definition rather than two that can drift.

## Verification

Confirmed causally against production (`layerswap.io/app`), reading the live provider registry out of the React fiber:

**Baseline** — valid amount, quote loaded, button disabled. Exactly one provider fails the gate:

| provider | isStub | ready | passes gate |
|---|---|---|---|
| evm, fuel, tron | no | true | ✅ |
| starknet, bitcoin, ton, solana, imtblPassport | yes | false | ✅ (stubs exempt) |
| **paradex** | **no** | **false** | ❌ |

**Intervention** — set `ready: true` on the Starknet stub only, keeping `isStub: true`; nothing written to the Paradex store, nothing hydrated.

**Result** — Paradex's `ready` recomputed to `true` on its own via the shipped `isReady()`, blockers went to `[]`, and the button went `disabled: false`. The other stubs stayed unhydrated at `ready: false` throughout, so one input changed and one output changed.

`pnpm build:packages` passes (exit 0, no TS errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)