### PR TITLE
fix(wallets): stop stale bigmi markers re-prompting the wallet every load

### DIFF
--- a/packages/wallets/all/src/descriptors/bitcoin.ts
+++ b/packages/wallets/all/src/descriptors/bitcoin.ts
@@ -1,6 +1,6 @@
 import type { WalletProviderDescriptor } from "@layerswap/widget/types"
 import { defineWalletDescriptor } from "./defineWalletDescriptor"
-import { hasStorageKey } from "./persistedSession"
+import { hasStorageKeyMatching } from "./persistedSession"
 
 const BITCOIN_NETWORKS = ['BITCOIN_MAINNET', 'BITCOIN_TESTNET']
 
@@ -20,9 +20,13 @@ export function createBitcoinDescriptor(): WalletProviderDescriptor {
         // without it the pre-hydration stub counts Bitcoin as mobile-supported,
         // flipping platform-gated state once the descriptor loads.
         unsupportedPlatforms: ['mobile'],
-        // @bigmi/client's `<prefix>.recentConnectorId` — what its reconnect()
-        // (called in wallet-bitcoin's getBitcoinConfig) restores from.
-        hasPersistedSession: () => hasStorageKey('bigmi.recentConnectorId'),
+        // `bigmi.<connectorId>.connected` — written on a successful connect,
+        // removed on disconnect, and the flag bigmi's own `isAuthorized()`
+        // gates its reconnect on. Deliberately not `bigmi.recentConnectorId`:
+        // bigmi only ever writes that key, so it outlives disconnects and
+        // rejected reconnects and kept hydrating Bitcoin (re-prompting the
+        // wallet) on every load for anyone who had ever connected one.
+        hasPersistedSession: () => hasStorageKeyMatching(/^bigmi\..+\.connected$/),
         loadProvider: async () => {
             const mod = await import('@layerswap/wallet-bitcoin')
             return mod.createBitcoinProvider()

--- a/packages/wallets/all/src/descriptors/persistedSession.ts
+++ b/packages/wallets/all/src/descriptors/persistedSession.ts
@@ -12,6 +12,25 @@ export function hasStorageKey(key: string): boolean {
     }
 }
 
+/**
+ * True when any localStorage key matches. For SDKs that namespace their session
+ * flag per connector (bigmi writes `bigmi.<connectorId>.connected`), where the
+ * exact key isn't knowable without importing the connector ids from the SDK
+ * this probe exists to avoid loading.
+ */
+export function hasStorageKeyMatching(pattern: RegExp): boolean {
+    if (typeof window === 'undefined') return false
+    try {
+        for (let i = 0; i < window.localStorage.length; i++) {
+            const key = window.localStorage.key(i)
+            if (key && pattern.test(key)) return true
+        }
+        return false
+    } catch {
+        return false
+    }
+}
+
 export function readStorageJson(key: string): unknown {
     if (typeof window === 'undefined') return undefined
     try {

--- a/packages/wallets/bitcoin/src/service/getBitcoinConfig.ts
+++ b/packages/wallets/bitcoin/src/service/getBitcoinConfig.ts
@@ -60,10 +60,42 @@ export function ensureBitcoinConfig(network: NetworkWithTokens | undefined): Con
     _configKey = nextConfigKey
 
     if (typeof window !== 'undefined') {
-        reconnect(_config).catch(() => { /* swallow */ })
+        void restoreSession(_config)
     }
 
     return _config
+}
+
+/**
+ * Eager session restore, plus cleanup of the markers it runs off.
+ *
+ * bigmi's connectors authorize purely off their own `<id>.connected`
+ * localStorage flag instead of asking the wallet, and its MetaMask connector
+ * then issues a real `bitcoin:connect` request. So a flag left behind by a
+ * session the wallet no longer honors makes every page load prompt the
+ * wallet — and bigmi clears neither that flag nor `recentConnectorId` when the
+ * attempt fails, so rejecting the prompt changed nothing and it returned on the
+ * next load, indefinitely. Clearing the markers whenever a restore yields no
+ * connection caps that at a single prompt.
+ *
+ * The cost is that a restore which fails for a transient reason (wallet locked,
+ * extension slow past bigmi's 5s poll) also drops the markers, so that wallet
+ * won't auto-restore next load and has to be reconnected by hand. That is the
+ * better failure: the markers claimed a connection the wallet was not honoring.
+ */
+async function restoreSession(config: Config): Promise<void> {
+    let restored: readonly unknown[] = []
+    try {
+        restored = await reconnect(config)
+    } catch { /* fall through to cleanup */ }
+    if (restored.length) return
+
+    try {
+        await Promise.all([
+            config.storage?.removeItem('recentConnectorId'),
+            ...config.connectors.map(c => config.storage?.removeItem(`${c.id}.connected`)),
+        ])
+    } catch { /* storage unavailable — nothing to clean up */ }
 }
 
 export function resetBitcoinConfig(): void {


### PR DESCRIPTION
## Problem

Loading the app fires a **MetaMask connection dialog with no user action**, on routes that have nothing to do with Bitcoin. Rejecting it doesn't help — the identical prompt returns on every subsequent load, indefinitely.

Reproduced on production and confirmed by deleting the two markers below by hand: the popup stopped, and the live provider registry then showed `bitcoin` as an unhydrated stub instead of a live `ready: true` provider.

## Root cause

Five links:

1. **The Bitcoin descriptor hydrates eagerly.** `hasPersistedSession()` returning true makes `LayerswapProvider` load the provider immediately on mount (`LayerswapProvider.tsx:295-304`), so a restored wallet surfaces without opening the modal. Bitcoin probed `bigmi.recentConnectorId`.
2. **That key is not a session signal.** In `@bigmi/client@0.10.1` it is only ever `setItem`'d — there is no `removeItem` for it anywhere, including `disconnect`. It means "the last connector you used", and it survives disconnects and rejected reconnects permanently.
3. **Hydration runs a reconnect** — `initBitcoinProvider` → `ensureBitcoinConfig` → `reconnect(_config)`.
4. **bigmi's authorization check never asks the wallet.** The MetaMask Bitcoin connector implements it as a bare localStorage read:
   ```ts
   async isAuthorized() {
     const isConnected = shimDisconnect && Boolean(await config.storage?.getItem(`${this.id}.connected`))
     return isConnected
   }
   ```
   (Contrast wagmi's EVM connectors, which call `eth_accounts` — a real, silent query. That's why the EVM side never prompted.)
5. **So it proceeds to `connect()`, a genuine connection request:**
   ```ts
   const { accounts } = await wallet.features['bitcoin:connect'].connect({ purposes: ['payment'] })
   ```
   `bitcoin:connect` is the Wallet Standard *connect* feature, not a silent account read.

Once that flag outlives the permission MetaMask actually grants, every load prompts — and `reconnect(_config).catch(() => { /* swallow */ })` discarded the `UserRejectedRequestError` without clearing anything, so rejecting changed no state and the next load reproduced it exactly.

Two distinct over-triggers, hitting different populations:

| | Triggered by | Who |
|---|---|---|
| Eager SDK load + reconnect | `bigmi.recentConnectorId` (never deleted) | anyone who *ever* connected a BTC wallet |
| The popup | `bigmi.<id>.connected` outliving the wallet's permission | the subset whose flag went stale |

## Fix

**Cap the loop** (`getBitcoinConfig.ts`) — `reconnect()` resolves to `Connection[]` with per-connector failures caught internally, so an empty array means "restored nothing". Clear the markers it ran off in that case, making a stale flag cost at most one prompt instead of an unbounded loop.

**Stop the needless hydration** (`descriptors/bitcoin.ts`) — probe `bigmi.<connectorId>.connected`, the flag bigmi itself authorizes on, so a cleanly disconnected wallet doesn't hydrate Bitcoin at all (and skips the ~88 KB gzip chunk). The connector id is embedded in the key and can't be named without importing the SDK the descriptor exists to defer, hence the small `hasStorageKeyMatching` helper.

The regex was validated against real localStorage keys: matches `bigmi.io.metamask.bitcoin.connected`; correctly does **not** match `bigmi.recentConnectorId`, `bigmi.store`, or `bigmi.app.phantom.bitcoin.**dis**connected`.

Both parts are needed: the probe change alone still prompts anyone already carrying a stale flag, and the cleanup alone leaves a probe that lies about having a session.

`pnpm build:packages` passes (exit 0, no TS errors).

## Reviewer call

A restore that fails for a **transient** reason — wallet locked, extension slower than bigmi's 5s provider poll — also clears the markers, so that wallet won't auto-restore next load and needs a manual reconnect. I took that over the popup loop, on the grounds that the markers were asserting a connection the wallet wasn't honouring. The narrower alternative is clearing only on an explicit `UserRejectedRequestError`, which leaves other stuck states looping. Happy to switch if you'd rather.

Not attempted here: dropping the eager Bitcoin reconnect entirely. That would remove even the single prompt, but it works against the descriptor design of surfacing restored sessions without opening the modal — a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)