### PR TITLE
fix: featured wallets not being displayed in search

### DIFF
--- a/packages/wallets/evm/src/service/EvmConnectionService.ts
+++ b/packages/wallets/evm/src/service/EvmConnectionService.ts
@@ -195,13 +195,14 @@ export class EvmConnectionService implements WalletConnectionService<RuntimeDeps
             return { connectors: [], nextPage: null, totalCount: 0 }
         }
         const result = await fn(params)
-        const additional = splitRegistryConnectors(
+        const { featured, additional } = splitRegistryConnectors(
             result.connectors,
             this._deps.isMobilePlatform ?? false,
             PROVIDER_NAME,
-        ).additional
+        )
+        const connectors = params.query?.trim() ? [...featured, ...additional] : additional
         return {
-            connectors: additional,
+            connectors,
             nextPage: result.nextPage,
             totalCount: result.totalCount,
         }


### PR DESCRIPTION
fix issue with featured wallets not being displayed in search untill we get them from getWallets calls as aditional wallets