### PR TITLE
fix: surface limits endpoint errors in swap form validation

### DIFF
--- a/packages/widget/core/src/context/validationContext.tsx
+++ b/packages/widget/core/src/context/validationContext.tsx
@@ -50,7 +50,10 @@ export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children
     const quoteArgs = useMemo(() => transformFormValuesToQuoteArgs(values), [values]);
     const quoteRefreshInterval = !!swapId ? 0 : undefined;
     // Deposit address flow doesn't use limits — resolveFormValidation skips amount checks there
-    const { minAllowedAmount, maxAllowedAmount, minAllowedAmountInUsd, maxAllowedAmountInUsd, quoteError, quote, isQuoteLoading, isDebouncing } = useQuoteData(quoteArgs, { refreshInterval: quoteRefreshInterval, skipLimits: isDepositAddressFlow(values.depositMethod, values.fromExchange) });
+    const { minAllowedAmount, maxAllowedAmount, minAllowedAmountInUsd, maxAllowedAmountInUsd, quoteError, limitsError, quote, isQuoteLoading, isDebouncing } = useQuoteData(quoteArgs, { refreshInterval: quoteRefreshInterval, skipLimits: isDepositAddressFlow(values.depositMethod, values.fromExchange) });
+
+    // Fall back to the limits error only when there are no usable limits at all, so a transient revalidation failure doesn't override a working quote
+    const routeError = quoteError ?? ((minAllowedAmount == undefined && maxAllowedAmount == undefined) ? limitsError : undefined);
 
     const { autoSlippage } = useSlippageStore();
     const quoteErrorCode = quoteError?.response?.data?.error?.code || quoteError?.code;
@@ -59,7 +62,7 @@ export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children
 
     const { networks: exchangeWithdrawalNetworks, isLoading: exchangeNetworksLoading, isValidating: exchangeNetworksValidating } = useExchangeNetworks({ fromExchange: values.fromExchange?.name, to: values.to?.name, toAsset: values.toAsset?.symbol });
     const noExchangeWithdrawalRoute = !!values.fromExchange && !!values.to && !!values.toAsset && !exchangeNetworksLoading && !exchangeNetworksValidating && (exchangeWithdrawalNetworks?.length ?? 0) === 0;
-    const routeValidation = useRouteValidation(quoteError, !!quote, isQuoteLoading || isDebouncing, autoSlippageWouldWork);
+    const routeValidation = useRouteValidation(routeError, !!quote, isQuoteLoading || isDebouncing, autoSlippageWouldWork);
 
     const isUsdMode = useUsdModeStore(s => s.isUsdMode);
 
@@ -72,7 +75,7 @@ export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children
         isUsdMode,
         sourceAddress: selectedSourceAccount?.address,
         sameAccountNetwork,
-        quoteError,
+        quoteError: routeError,
         noExchangeWithdrawalRoute
     })
 

--- a/packages/widget/core/src/hooks/useFee.tsx
+++ b/packages/widget/core/src/hooks/useFee.tsx
@@ -30,6 +30,7 @@ type UseQuoteData = {
     quote?: Quote
     quoteTokenPrices?: QuoteTokenPrices
     quoteError?: QuoteError
+    limitsError?: QuoteError
     isQuoteLoading: boolean
     isDebouncing: boolean
     mutateFee: () => void
@@ -140,7 +141,7 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
             destinationAddress,
         }) : null
 
-    const { data: amountRange, mutate: mutateLimits, isValidating: limitsValidating } = useSWR<ApiResponse<{
+    const { data: amountRange, mutate: mutateLimits, isValidating: limitsValidating, error: limitsError } = useSWR<ApiResponse<{
         min_amount: number
         min_amount_in_usd: number
         max_amount: number
@@ -252,6 +253,7 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
         isQuoteLoading,
         isDebouncing,
         quoteError,
+        limitsError,
         mutateFee,
         mutateLimits,
         limitsValidating,


### PR DESCRIPTION
## Problem

The swap form only surfaced errors from the `/quote` endpoint. The limits SWR call in `useQuoteData` never destructured `error`, so a failing `/limits` request was silently swallowed:

- `minAllowedAmount`/`maxAllowedAmount` came back `undefined`, so the min/max checks in `resolveFormValidation` silently passed — users could proceed with an out-of-range amount and only hit the error at swap creation.
- The gap was widest before an amount is entered: `/limits` fires as soon as route params exist, while `/quote` requires an amount. On a broken route with no amount typed, the limits failure was the only signal — and it was discarded.

## Fix

- `useQuoteData` now captures and returns `limitsError?: QuoteError` (both endpoints share the same error envelope, so the existing type fits).
- `ValidationProvider` derives `routeError = quoteError ?? limitsError` and passes it to both `useRouteValidation` and `resolveFormValidation`. Quote errors keep precedence since they're amount-specific.
- The limits error is only used when both min and max amounts are absent — SWR keeps the last successful limits data during background refresh, so a transient blip won't flash "Route not found" over a working quote.

The auto-slippage test gate still keys off `quoteError` alone, which is correct since it specifically probes quote/slippage behavior.

## Verification

`pnpm check:types` passes in `packages/widget/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)