### PR TITLE
Foreground WC mobile wallet app before Solana sign requests

### DIFF
--- a/packages/wallets/adapters/evm/src/gaslessProvider/createEVMGaslessProvider.ts
+++ b/packages/wallets/adapters/evm/src/gaslessProvider/createEVMGaslessProvider.ts
@@ -1,4 +1,4 @@
-import { isMobile } from "@layerswap/utils";
+import { foregroundWalletApp } from "@layerswap/wallet-core";
 import { Network } from "@layerswap/widget-types";
 import { GaslessProvider, GaslessSignParams } from "@layerswap/widget-types";
 import { getAccount, Config } from '@wagmi/core'
@@ -21,10 +21,7 @@ export function createEVMGaslessProvider(
             if (!walletProvider?.request)
                 throw new Error('Wallet provider unavailable')
 
-            if (isMobile() && wallet?.metadata?.deepLink) {
-                window.location.href = wallet.metadata.deepLink
-                await new Promise(resolve => setTimeout(resolve, 100))
-            }
+            await foregroundWalletApp(wallet?.metadata?.deepLink)
 
             const signature = await walletProvider.request({
                 method: 'eth_signTypedData_v4',

--- a/packages/wallets/adapters/evm/src/transferProvider/createEVMTransferProvider.ts
+++ b/packages/wallets/adapters/evm/src/transferProvider/createEVMTransferProvider.ts
@@ -3,7 +3,7 @@ import { Network } from "@layerswap/widget-types";
 import { TransferProvider, TransferProps } from "@layerswap/widget-types";
 import { sendTransaction, Config } from '@wagmi/core'
 import { BaseError } from "viem"
-import { isMobile } from "@layerswap/utils"
+import { foregroundWalletApp } from "@layerswap/wallet-core"
 import { resolveError } from "../evmUtils/resolveError"
 
 type TransactionBuilder = (params: TransferProps) => Promise<any>
@@ -22,10 +22,7 @@ export function createEVMTransferProvider(
             try {
                 const tx = await buildTransaction(params)
 
-                if (isMobile() && selectedWallet?.metadata?.deepLink) {
-                    window.location.href = selectedWallet.metadata.deepLink
-                    await new Promise(resolve => setTimeout(resolve, 100))
-                }
+                await foregroundWalletApp(selectedWallet?.metadata?.deepLink)
 
                 const hash = await sendTransaction(config, tx)
 

--- a/packages/wallets/adapters/svm/src/service/SvmConnectionService.ts
+++ b/packages/wallets/adapters/svm/src/service/SvmConnectionService.ts
@@ -153,6 +153,7 @@ export class SvmConnectionService<Network> implements WalletConnectionService<Ru
             autofillSupportedNetworks: supported,
             withdrawalSupportedNetworks: supported,
             networkIcon: this.getNetworkIcon(),
+            metadata: { deepLink: dynamicMeta?.deepLink },
         }
     }
 
@@ -254,6 +255,7 @@ export class SvmConnectionService<Network> implements WalletConnectionService<Ru
 
             isWc = !!useWalletConnect && matched
             const identity = isWc ? (matchedRegistry ?? connector) : undefined
+            const wcDeepLink = isWc ? (mobile?.native || mobile?.universal || undefined) : undefined
 
             const targetAdapter = useWalletConnect ? hiddenWcAdapter : installedAdapter
             if (!targetAdapter) throw new Error('Connector not found')
@@ -275,7 +277,7 @@ export class SvmConnectionService<Network> implements WalletConnectionService<Ru
             if (useWalletConnect && hiddenWcAdapter) {
                 const wcAdapter = hiddenWcAdapter as unknown as SolanaWalletConnectAdapter
 
-                setPendingMetadataForRegistry(SVM_NS, identity)
+                setPendingMetadataForRegistry(SVM_NS, identity ? { ...identity, deepLink: wcDeepLink } : undefined)
 
                 const wantsQrModal = !isMobilePlatform || !resolveURI
                 if (wantsQrModal) {
@@ -315,6 +317,7 @@ export class SvmConnectionService<Network> implements WalletConnectionService<Ru
                     name: identity.name,
                     icon: identity.icon || '',
                     id: identity.id,
+                    deepLink: wcDeepLink,
                 })
             }
 
@@ -339,6 +342,7 @@ export class SvmConnectionService<Network> implements WalletConnectionService<Ru
                 autofillSupportedNetworks: supported,
                 withdrawalSupportedNetworks: supported,
                 networkIcon: this.getNetworkIcon(),
+                metadata: { deepLink: wcDeepLink },
             }
             return wallet
         } catch (e) {

--- a/packages/wallets/adapters/svm/src/transferProvider/createSvmTransfer.ts
+++ b/packages/wallets/adapters/svm/src/transferProvider/createSvmTransfer.ts
@@ -32,11 +32,12 @@ export function createSvmTransfer(): TransferProvider {
                     LAMPORTS_PER_SOL,
                 )
 
+                await foregroundWalletApp(params.selectedWallet?.metadata?.deepLink)
+
                 const signature = await configureAndSendCurrentTransaction(
                     transaction,
                     connection,
                     signTransaction,
-                    () => foregroundWalletApp(params.selectedWallet?.metadata?.deepLink),
                 )
 
                 if (!signature) {

--- a/packages/wallets/adapters/svm/src/transferProvider/createSvmTransfer.ts
+++ b/packages/wallets/adapters/svm/src/transferProvider/createSvmTransfer.ts
@@ -1,6 +1,7 @@
 import { NetworkType, ActionMessageType } from '@layerswap/widget-types';
 import { Network } from "@layerswap/widget-types";
 import { TransferProvider, TransferProps } from "@layerswap/widget-types";
+import { foregroundWalletApp } from "@layerswap/wallet-core"
 import type { Connection, Transaction } from "@solana/web3.js"
 import { configureAndSendCurrentTransaction } from "./transactionSender"
 import { svmAdapterManager } from "../service/svmAdapterManager"
@@ -35,6 +36,7 @@ export function createSvmTransfer(): TransferProvider {
                     transaction,
                     connection,
                     signTransaction,
+                    () => foregroundWalletApp(params.selectedWallet?.metadata?.deepLink),
                 )
 
                 if (!signature) {

--- a/packages/wallets/adapters/svm/src/transferProvider/transactionSender.ts
+++ b/packages/wallets/adapters/svm/src/transferProvider/transactionSender.ts
@@ -6,16 +6,12 @@ export const configureAndSendCurrentTransaction = async (
     transaction: Transaction,
     connection: Connection,
     signTransaction: SignerWalletAdapterProps['signTransaction'],
-    // Runs after the blockhash fetch so a wallet-foregrounding redirect fires
-    // immediately before the sign request, not before the RPC round trip.
-    onBeforeSign?: () => Promise<void>
 ) => {
 
     const blockHash = await connection.getLatestBlockhash();
     transaction.recentBlockhash = blockHash.blockhash;
     transaction.lastValidBlockHeight = blockHash.lastValidBlockHeight;
 
-    await onBeforeSign?.();
     const signed = await signTransaction(transaction);
 
     const res = await transactionSenderAndConfirmationWaiter({

--- a/packages/wallets/adapters/svm/src/transferProvider/transactionSender.ts
+++ b/packages/wallets/adapters/svm/src/transferProvider/transactionSender.ts
@@ -5,13 +5,17 @@ import { transactionSenderAndConfirmationWaiter } from './transactionBuilder';
 export const configureAndSendCurrentTransaction = async (
     transaction: Transaction,
     connection: Connection,
-    signTransaction: SignerWalletAdapterProps['signTransaction']
+    signTransaction: SignerWalletAdapterProps['signTransaction'],
+    // Runs after the blockhash fetch so a wallet-foregrounding redirect fires
+    // immediately before the sign request, not before the RPC round trip.
+    onBeforeSign?: () => Promise<void>
 ) => {
 
     const blockHash = await connection.getLatestBlockhash();
     transaction.recentBlockhash = blockHash.blockhash;
     transaction.lastValidBlockHeight = blockHash.lastValidBlockHeight;
 
+    await onBeforeSign?.();
     const signed = await signTransaction(transaction);
 
     const res = await transactionSenderAndConfirmationWaiter({

--- a/packages/wallets/core/src/index.ts
+++ b/packages/wallets/core/src/index.ts
@@ -15,6 +15,8 @@ export {
     createMemoizedConnectionStore,
     setDynamicWcMetadata,
     setPendingMetadataForRegistry,
+    foregroundWalletApp,
+    isSafeDeepLink,
     getAdditionalConnectorsStore,
     getInstantiatedAdditionalConnectorsStores,
     subscribeAdditionalConnectorsStores,

--- a/packages/wallets/core/src/lib/walletConnect/dynamicMetadata.ts
+++ b/packages/wallets/core/src/lib/walletConnect/dynamicMetadata.ts
@@ -93,7 +93,7 @@ export const clearPendingDynamicWcMetadata = (namespace: string): void => {
  */
 export const setPendingMetadataForRegistry = (
     namespace: string,
-    registry: { name: string; icon?: string; id: string } | undefined
+    registry: { name: string; icon?: string; id: string; deepLink?: string } | undefined
 ): DynamicWcMetadata | undefined => {
     if (!registry) {
         clearPendingDynamicWcMetadata(namespace)
@@ -103,6 +103,7 @@ export const setPendingMetadataForRegistry = (
         name: registry.name,
         icon: registry.icon || '',
         id: registry.id,
+        deepLink: registry.deepLink,
     }
     setPendingDynamicWcMetadata(namespace, meta)
     return meta

--- a/packages/wallets/core/src/lib/walletConnect/foregroundWalletApp.ts
+++ b/packages/wallets/core/src/lib/walletConnect/foregroundWalletApp.ts
@@ -1,0 +1,21 @@
+import { isMobile } from "@layerswap/utils"
+
+export const isSafeDeepLink = (link: string): boolean => {
+    try {
+        const protocol = new URL(link).protocol
+        return protocol !== 'javascript:' && protocol !== 'data:'
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Foregrounds the connected wallet app right before a sign request.
+ * WC-connected wallets on mobile receive the request over the relay while
+ * backgrounded — without this the OS never shows the open-in-wallet prompt.
+ */
+export const foregroundWalletApp = async (deepLink: string | undefined): Promise<void> => {
+    if (!isMobile() || !deepLink || !isSafeDeepLink(deepLink)) return
+    window.location.href = deepLink
+    await new Promise(resolve => setTimeout(resolve, 100))
+}

--- a/packages/wallets/core/src/lib/walletConnect/index.ts
+++ b/packages/wallets/core/src/lib/walletConnect/index.ts
@@ -4,6 +4,7 @@ export * from "./createRegistryConnector"
 export * from "./connectorSource"
 export * from "./decorateForWagmi"
 export * from "./dynamicMetadata"
+export * from "./foregroundWalletApp"
 export * from './mapConnectError'
 export * from "./mapWallet"
 export * from "./registry"

--- a/packages/wallets/core/src/lib/walletConnect/subscribeDisplayUri.ts
+++ b/packages/wallets/core/src/lib/walletConnect/subscribeDisplayUri.ts
@@ -1,3 +1,4 @@
+import { isSafeDeepLink } from "./foregroundWalletApp"
 import type { QrCodeState } from "./types"
 
 export type DisplayUriListener = (uri: string) => void
@@ -35,15 +36,8 @@ export function subscribeDisplayUri(params: SubscribeDisplayUriParams): () => vo
         const deepLink = resolveURI ? resolveURI(uri) : undefined
 
         if (isMobilePlatform && deepLink) {
-            try {
-                const url = new URL(deepLink)
-                if (url.protocol === 'javascript:' || url.protocol === 'data:') {
-                    console.warn('Blocked navigation to untrusted URL scheme')
-                    onQr({ state: 'fetched', value: uri, deepLink })
-                    return
-                }
-            } catch {
-                console.warn('Blocked navigation to malformed URL')
+            if (!isSafeDeepLink(deepLink)) {
+                console.warn('Blocked navigation to untrusted or malformed URL')
                 onQr({ state: 'fetched', value: uri, deepLink })
                 return
             }

--- a/packages/wallets/core/src/lib/walletConnect/types.ts
+++ b/packages/wallets/core/src/lib/walletConnect/types.ts
@@ -28,6 +28,9 @@ export type DynamicWcMetadata = {
     name: string
     icon: string
     id: string
+    /** Bare mobile deep-link of the connected WC wallet (native scheme or
+     *  universal link), used to foreground the wallet app at signing time. */
+    deepLink?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

WalletConnect-connected wallets on mobile receive sign requests over the relay while the wallet app is backgrounded, so the OS never shows the open-in-wallet prompt and the swap appears to hang. This ports the existing EVM fix to Solana:

- **Connect time** (`SvmConnectionService`): capture the WC wallet's deep link (`mobile.native || mobile.universal`) from the registry entry, persist it in the dynamic WC metadata, and expose it as `wallet.metadata.deepLink`.
- **Sign time** (`createSvmTransfer`): redirect to the deep link right before `signTransaction`, threaded via a new optional `onBeforeSign` callback on `configureAndSendCurrentTransaction` so it fires *after* the `getLatestBlockhash` RPC round trip — redirecting any earlier would background the page again before the sign request goes out.

## Hardening / cleanup (from PR review)

- The redirect is extracted into a shared `foregroundWalletApp` helper in `wallet-core` that validates the URL scheme (rejects `javascript:`/`data:`), reusing the same guard `subscribeDisplayUri` already had — which now shares the same `isSafeDeepLink` predicate. The two pre-existing, previously-unvalidated EVM copies of the snippet (`createEVMTransferProvider`, `createEVMGaslessProvider`) now use the helper too.
- `setPendingMetadataForRegistry` takes a plain `deepLink?: string` instead of the registry `mobile` object, so EVM's call site no longer silently persists a deep link it never reads.
- SVM's `Wallet.metadata` is now always an object (matching EVM's shape for the same contract).

## Follow-up (not in this PR)

- TON's wallet-open redirect (`createTonTransfer.ts`) still navigates without scheme validation; its snippet has a different shape (no mobile gate/delay), so it should be hardened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)