### PR TITLE
fix(evm): handle Monad gas and reserve balance, resolves BAB-273

### DIFF
--- a/packages/wallets/adapters/evm/package.json
+++ b/packages/wallets/adapters/evm/package.json
@@ -30,7 +30,8 @@
     "build:esm+types": "tsc --project tsconfig.json --rootDir ./src --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types && tsc-alias -p tsconfig.json --outDir ./dist/esm && tsc-alias -p tsconfig.json --outDir ./dist/types",
     "check:types": "tsc --noEmit",
     "clean": "rimraf dist tsconfig.tsbuildinfo actions chains codegen experimental internal query",
-    "dev": "tsc --project tsconfig.json --rootDir ./src --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types --watch"
+    "dev": "tsc --project tsconfig.json --rootDir ./src --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types --watch",
+    "test": "pnpm build:esm+types && node --test tests/*.test.mjs"
   },
   "author": "Layerswap",
   "homepage": "https://github.com/layerswap/layerswapapp",

--- a/packages/wallets/adapters/evm/src/gasProviders/evmGasMath.ts
+++ b/packages/wallets/adapters/evm/src/gasProviders/evmGasMath.ts
@@ -1,0 +1,75 @@
+import { BASIS_POINTS, type EVMGasPolicy } from "./evmGasPolicies.js";
+
+export const applyGasLimitMargin = (estimatedGas: bigint, policy: EVMGasPolicy) =>
+    (estimatedGas * policy.gasLimitMarginBps + BASIS_POINTS - 1n) / BASIS_POINTS
+
+const EIP7702_DELEGATION_DESIGNATOR = /^0xef0100[0-9a-f]{40}$/i
+
+export const isEIP7702DelegatedCode = (accountCode?: `0x${string}`) =>
+    accountCode !== undefined && EIP7702_DELEGATION_DESIGNATOR.test(accountCode)
+
+export const resolveAccountBalanceReserve = ({
+    policy,
+    accountCode,
+}: {
+    policy: EVMGasPolicy
+    accountCode?: `0x${string}`
+}) => {
+    const reserve = policy.accountBalanceReserve
+    if (!reserve) return 0n
+
+    switch (reserve.condition) {
+        case 'eip7702-delegated':
+            return isEIP7702DelegatedCode(accountCode) ? reserve.amount : 0n
+    }
+}
+
+type CalculateGasFeeAmountsArgs = {
+    policy: EVMGasPolicy
+    estimatedGas: bigint
+    gasPrice?: bigint
+    maxFeePerGas?: bigint
+}
+
+export const calculateGasFeeAmounts = ({
+    policy,
+    estimatedGas,
+    gasPrice,
+    maxFeePerGas,
+}: CalculateGasFeeAmountsArgs) => {
+    const maximumGasPrice = maxFeePerGas ?? gasPrice
+    if (maximumGasPrice === undefined) return undefined
+
+    const gasLimit = applyGasLimitMargin(estimatedGas, policy)
+    const expectedGasPrice = policy.feeQuoteMode === 'current-capped' && gasPrice !== undefined
+        ? gasPrice < maximumGasPrice ? gasPrice : maximumGasPrice
+        : maximumGasPrice
+
+    return {
+        gasLimit,
+        estimatedFee: gasLimit * expectedGasPrice,
+        maximumFee: gasLimit * maximumGasPrice,
+    }
+}
+
+type BuildTransactionGasParametersArgs = {
+    policy: EVMGasPolicy
+    estimatedGas: bigint
+    maxFeePerGas: bigint
+    maxPriorityFeePerGas: bigint
+}
+
+export const buildTransactionGasParameters = ({
+    policy,
+    estimatedGas,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+}: BuildTransactionGasParametersArgs) => {
+    if (policy.transactionGasMode !== 'explicit-eip1559') return undefined
+
+    return {
+        gas: applyGasLimitMargin(estimatedGas, policy),
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+    }
+}

--- a/packages/wallets/adapters/evm/src/gasProviders/evmGasPolicies.ts
+++ b/packages/wallets/adapters/evm/src/gasProviders/evmGasPolicies.ts
@@ -1,0 +1,75 @@
+export const BASIS_POINTS = 10_000n
+
+export type EVMFeeQuoteMode = 'maximum' | 'current-capped'
+export type EVMTransactionGasMode = 'wallet' | 'explicit-eip1559'
+export type EVMAccountReserveCondition = 'eip7702-delegated'
+
+export type EVMAccountBalanceReserve = Readonly<{
+    amount: bigint
+    condition: EVMAccountReserveCondition
+}>
+
+export type EVMGasPolicy = Readonly<{
+    gasLimitMarginBps: bigint
+    feeQuoteMode: EVMFeeQuoteMode
+    reserveMaximumFee: boolean
+    transactionGasMode: EVMTransactionGasMode
+    accountBalanceReserve?: EVMAccountBalanceReserve
+}>
+
+const DEFAULT_EVM_GAS_POLICY: EVMGasPolicy = Object.freeze({
+    gasLimitMarginBps: BASIS_POINTS,
+    feeQuoteMode: 'maximum',
+    reserveMaximumFee: false,
+    transactionGasMode: 'wallet',
+})
+
+export const createEVMGasPolicy = (
+    overrides: Partial<EVMGasPolicy> = {},
+): EVMGasPolicy => {
+    const policy = { ...DEFAULT_EVM_GAS_POLICY, ...overrides }
+    if (policy.gasLimitMarginBps < BASIS_POINTS) {
+        throw new Error('EVM gas-limit margin cannot be lower than 100%')
+    }
+
+    return Object.freeze(policy)
+}
+
+/**
+ * Reusable policy for EIP-1559 chains that charge the signed gas limit instead
+ * of refunding unused gas. It keeps quotes honest while making the signed limit
+ * and fee cap deterministic.
+ */
+export const createFullGasLimitEIP1559Policy = ({
+    gasLimitMarginBps,
+    accountBalanceReserve,
+}: {
+    gasLimitMarginBps: bigint
+    accountBalanceReserve?: EVMAccountBalanceReserve
+}) =>
+    createEVMGasPolicy({
+        gasLimitMarginBps,
+        feeQuoteMode: 'current-capped',
+        reserveMaximumFee: true,
+        transactionGasMode: 'explicit-eip1559',
+        accountBalanceReserve,
+    })
+
+const MONAD_ACCOUNT_RESERVE = 10n * 10n ** 18n
+const MONAD_GAS_POLICY = createFullGasLimitEIP1559Policy({
+    gasLimitMarginBps: 10_750n,
+    accountBalanceReserve: {
+        amount: MONAD_ACCOUNT_RESERVE,
+        condition: 'eip7702-delegated',
+    },
+})
+
+const EVM_GAS_POLICIES_BY_CHAIN_ID = new Map<number, EVMGasPolicy>([
+    // Monad charges the complete signed gas limit and applies a 10 MON reserve
+    // to EIP-7702-delegated accounts.
+    [143, MONAD_GAS_POLICY],
+    [10143, MONAD_GAS_POLICY],
+])
+
+export const resolveEVMGasPolicy = (chainId: number): EVMGasPolicy =>
+    EVM_GAS_POLICIES_BY_CHAIN_ID.get(chainId) ?? DEFAULT_EVM_GAS_POLICY

--- a/packages/wallets/adapters/evm/src/gasProviders/evmGasProvider.ts
+++ b/packages/wallets/adapters/evm/src/gasProviders/evmGasProvider.ts
@@ -7,6 +7,14 @@ import resolveChain from "../evmUtils/resolveChain";
 import NetworkSettings from "../NetworkSettings";
 import { ErrorHandler } from "@layerswap/widget-types";
 import { resolveFallbackTransport } from "../evmUtils/resolveTransports";
+import { calculateGasFeeAmounts, resolveAccountBalanceReserve } from "./evmGasMath";
+import { resolveEVMGasPolicy } from "./evmGasPolicies";
+
+type ResolvedGas = {
+    gas: number
+    maxFee?: number
+    balanceReserve?: number
+}
 
 export class EVMGasProvider implements GasProvider {
     supportsNetwork(network: Network): boolean {
@@ -45,10 +53,10 @@ export class EVMGasProvider implements GasProvider {
                 }
             )
 
-            const gas = await gasProvider.resolveGas()
+            const resolvedGas = await gasProvider.resolveGas()
 
-            if (gas) {
-                return { gas, token: network.token }
+            if (resolvedGas) {
+                return { ...resolvedGas, token: network.token }
             }
         }
         catch (e) {
@@ -107,7 +115,7 @@ abstract class getEVMGas {
         this.nativeToken = nativeToken
     }
 
-    abstract resolveGas(): Promise<number | undefined>
+    abstract resolveGas(): Promise<ResolvedGas | undefined>
 
     protected async resolveFeeData() {
 
@@ -228,23 +236,38 @@ abstract class getEVMGas {
 
 class getEthereumGas extends getEVMGas {
     resolveGas = async () => {
-        const [feeData, estimatedGasLimit] = await Promise.all([
+        const policy = resolveEVMGasPolicy(this.chainId)
+        const [feeData, estimatedGasLimit, accountCode] = await Promise.all([
             this.resolveFeeData(),
             this.contract_address
                 ? this.estimateERC20GasLimit()
-                : this.estimateNativeGasLimit()
+                : this.estimateNativeGasLimit(),
+            policy.accountBalanceReserve
+                ? this.publicClient.getCode({ address: this.account })
+                : Promise.resolve(undefined),
         ])
 
-        const multiplier = feeData.maxFeePerGas || feeData.gasPrice
+        const feeAmounts = calculateGasFeeAmounts({
+            policy,
+            estimatedGas: estimatedGasLimit,
+            gasPrice: feeData.gasPrice,
+            maxFeePerGas: feeData.maxFeePerGas,
+        })
 
-        if (!multiplier)
+        if (!feeAmounts)
             return undefined
 
-        const totalGas = multiplier * estimatedGasLimit
-
         const decimals = NetworkSettings.KnownSettings[this.from.name]?.FeeParsingDecimalPlaces || this.nativeToken?.decimals
-        const formattedGas = Number(formatUnits(BigInt(totalGas), decimals))
-        return formattedGas
+        const gas = Number(formatUnits(feeAmounts.estimatedFee, decimals))
+        const maxFee = Number(formatUnits(feeAmounts.maximumFee, decimals))
+        const accountBalanceReserve = resolveAccountBalanceReserve({ policy, accountCode })
+        const balanceReserve = Number(formatUnits(accountBalanceReserve, decimals))
+
+        return {
+            gas,
+            ...(policy.reserveMaximumFee ? { maxFee } : {}),
+            ...(balanceReserve > 0 ? { balanceReserve } : {}),
+        }
     }
 
 }
@@ -276,7 +299,7 @@ export default class getOptimismGas extends getEVMGas {
         let totalGas = (multiplier * estimatedGasLimit) + l1OpFee
 
         const formattedGas = Number(formatUnits(BigInt(totalGas), this.nativeToken?.decimals))
-        return formattedGas
+        return { gas: formattedGas }
     }
 
     private GetOpL1Fee = async (gasPrice: bigint): Promise<bigint> => {

--- a/packages/wallets/adapters/evm/src/gasProviders/resolveEVMTransactionGasParameters.ts
+++ b/packages/wallets/adapters/evm/src/gasProviders/resolveEVMTransactionGasParameters.ts
@@ -1,0 +1,48 @@
+import { Network } from "@layerswap/widget-types";
+import { createPublicClient } from "viem";
+import resolveChain from "../evmUtils/resolveChain";
+import { resolveFallbackTransport } from "../evmUtils/resolveTransports";
+import { buildTransactionGasParameters } from "./evmGasMath";
+import { resolveEVMGasPolicy } from "./evmGasPolicies";
+
+type ResolveEVMTransactionGasParametersArgs = {
+    network: Network
+    account: `0x${string}`
+    to: `0x${string}`
+    data?: `0x${string}`
+    value?: bigint
+}
+
+export const resolveEVMTransactionGasParameters = async ({
+    network,
+    account,
+    to,
+    data,
+    value,
+}: ResolveEVMTransactionGasParametersArgs) => {
+    const chainId = Number(network.chain_id)
+    const policy = resolveEVMGasPolicy(chainId)
+    if (policy.transactionGasMode === 'wallet') return undefined
+
+    const publicClient = createPublicClient({
+        chain: resolveChain(network),
+        transport: resolveFallbackTransport(network.nodes),
+    })
+
+    const [estimatedGas, feesPerGas] = await Promise.all([
+        publicClient.estimateGas({ account, to, data, value }),
+        publicClient.estimateFeesPerGas(),
+    ])
+
+    const { maxFeePerGas, maxPriorityFeePerGas } = feesPerGas
+    if (maxFeePerGas === undefined || maxPriorityFeePerGas === undefined) {
+        throw new Error(`EIP-1559 fee data is unavailable for chain ${chainId}`)
+    }
+
+    return buildTransactionGasParameters({
+        policy,
+        estimatedGas,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+    })
+}

--- a/packages/wallets/adapters/evm/src/transferProvider/transactionBuilder.ts
+++ b/packages/wallets/adapters/evm/src/transferProvider/transactionBuilder.ts
@@ -1,32 +1,26 @@
 import { TransferProps } from "@layerswap/widget-types";
 import { parseEther } from "viem"
-import { EVMGasProvider } from "../gasProviders"
+import { resolveEVMTransactionGasParameters } from "../gasProviders/resolveEVMTransactionGasParameters"
 
 export const transactionBuilder = async (params: TransferProps) => {
     const { amount, callData, depositAddress, network, selectedWallet, token } = params
-
+    const isNativeSource = !token?.contract
 
     const tx = {
         chainId: Number(network?.chain_id),
         to: depositAddress as `0x${string}`,
-        value: parseEther(amount.toString()),
-        gas: undefined as any,
+        value: isNativeSource ? parseEther(amount.toString()) : 0n,
         data: callData as `0x${string}`,
         account: selectedWallet.address as `0x${string}`
     }
 
-    try {
-        const gasData = await new EVMGasProvider().getGas({
-            address: selectedWallet.address,
-            network,
-            token
-        })
+    const gasParameters = await resolveEVMTransactionGasParameters({
+        network,
+        account: tx.account,
+        to: tx.to,
+        data: tx.data,
+        value: tx.value,
+    })
 
-        if (gasData?.gas) tx.gas = BigInt(gasData.gas)
-
-    } catch (error) {
-        console.log(error)
-    }
-
-    return tx
+    return gasParameters ? { ...tx, ...gasParameters } : tx
 }

--- a/packages/wallets/adapters/evm/tests/evmGasMath.test.mjs
+++ b/packages/wallets/adapters/evm/tests/evmGasMath.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    applyGasLimitMargin,
+    buildTransactionGasParameters,
+    calculateGasFeeAmounts,
+    isEIP7702DelegatedCode,
+    resolveAccountBalanceReserve,
+} from '../dist/esm/gasProviders/evmGasMath.js'
+import {
+    createFullGasLimitEIP1559Policy,
+    resolveEVMGasPolicy,
+} from '../dist/esm/gasProviders/evmGasPolicies.js'
+
+const monadPolicy = resolveEVMGasPolicy(143)
+const defaultPolicy = resolveEVMGasPolicy(1)
+
+test('applies Monad\'s 7.5% gas-limit margin with ceiling division', () => {
+    assert.equal(applyGasLimitMargin(22_515n, monadPolicy), 24_204n)
+    assert.equal(applyGasLimitMargin(22_515n, defaultPolicy), 22_515n)
+})
+
+test('separates Monad expected and maximum fees', () => {
+    const result = calculateGasFeeAmounts({
+        policy: monadPolicy,
+        estimatedGas: 22_515n,
+        gasPrice: 102_000_000_000n,
+        maxFeePerGas: 122_000_000_000n,
+    })
+
+    assert.deepEqual(result, {
+        gasLimit: 24_204n,
+        estimatedFee: 2_468_808_000_000_000n,
+        maximumFee: 2_952_888_000_000_000n,
+    })
+})
+
+test('preserves the maximum-fee quote on non-Monad EVM chains', () => {
+    assert.deepEqual(calculateGasFeeAmounts({
+        policy: defaultPolicy,
+        estimatedGas: 21_000n,
+        gasPrice: 30_000_000_000n,
+        maxFeePerGas: 40_000_000_000n,
+    }), {
+        gasLimit: 21_000n,
+        estimatedFee: 840_000_000_000_000n,
+        maximumFee: 840_000_000_000_000n,
+    })
+})
+
+test('builds policy-controlled transaction parameters in gas units', () => {
+    assert.deepEqual(buildTransactionGasParameters({
+        policy: monadPolicy,
+        estimatedGas: 22_515n,
+        maxFeePerGas: 122_000_000_000n,
+        maxPriorityFeePerGas: 2_000_000_000n,
+    }), {
+        gas: 24_204n,
+        maxFeePerGas: 122_000_000_000n,
+        maxPriorityFeePerGas: 2_000_000_000n,
+    })
+
+    assert.equal(buildTransactionGasParameters({
+        policy: defaultPolicy,
+        estimatedGas: 22_515n,
+        maxFeePerGas: 122_000_000_000n,
+        maxPriorityFeePerGas: 2_000_000_000n,
+    }), undefined)
+})
+
+test('a future full-gas-limit chain can configure the reusable policy', () => {
+    const futureChainPolicy = createFullGasLimitEIP1559Policy({
+        gasLimitMarginBps: 11_000n,
+    })
+
+    assert.deepEqual(buildTransactionGasParameters({
+        policy: futureChainPolicy,
+        estimatedGas: 21_000n,
+        maxFeePerGas: 50_000_000_000n,
+        maxPriorityFeePerGas: 3_000_000_000n,
+    }), {
+        gas: 23_100n,
+        maxFeePerGas: 50_000_000_000n,
+        maxPriorityFeePerGas: 3_000_000_000n,
+    })
+})
+
+test('reserves protocol balance only for an EIP-7702-delegated account', () => {
+    const delegatedCode = `0xef0100${'12'.repeat(20)}`
+
+    assert.equal(isEIP7702DelegatedCode(delegatedCode), true)
+    assert.equal(isEIP7702DelegatedCode('0x'), false)
+    assert.equal(resolveAccountBalanceReserve({
+        policy: monadPolicy,
+        accountCode: delegatedCode,
+    }), 10n * 10n ** 18n)
+    assert.equal(resolveAccountBalanceReserve({
+        policy: monadPolicy,
+        accountCode: undefined,
+    }), 0n)
+    assert.equal(resolveAccountBalanceReserve({
+        policy: defaultPolicy,
+        accountCode: delegatedCode,
+    }), 0n)
+})

--- a/packages/widget/core/src/components/Input/Amount/MinMax.tsx
+++ b/packages/widget/core/src/components/Input/Amount/MinMax.tsx
@@ -12,6 +12,7 @@ import { useUsdModeStore } from "@/stores/usdModeStore";
 import { skipNextUsdSync } from "@/hooks/useUsdTokenSync";
 import { ceilUsd, floorUsd } from "@/components/utils/formatUsdAmount";
 import { ceilToDecimals, roundToDecimals, truncateToDecimals, isScientific } from "@/components/utils/RoundDecimals";
+import { resolveGasBalanceBudget } from "@/lib/gases/resolveGasBalanceBudget";
 
 type MinMaxProps = {
     fromCurrency: NetworkRouteToken,
@@ -33,14 +34,14 @@ const MinMax = (props: MinMaxProps) => {
     const selectedSourceAccount = useSelectedAccount("from", from?.name);
     const { wallets } = useWallet(from, 'withdrawal')
     const wallet = wallets.find(w => w.id === selectedSourceAccount?.id)
-    const { gasData } = useSWRGas(selectedSourceAccount?.address, from, fromCurrency, values.amount, wallet)
+    const { gasData, isGasLoading, gasError } = useSWRGas(selectedSourceAccount?.address, from, fromCurrency, values.amount, wallet)
     const { balances, mutate: mutateBalances } = useBalance(selectedSourceAccount?.address, from)
 
     const walletBalance = useMemo(() => {
         return selectedSourceAccount?.address ? balances?.find(b => b?.network === from?.name && b?.token === fromCurrency?.symbol) : undefined
     }, [selectedSourceAccount?.address, balances, from?.name, fromCurrency?.symbol])
 
-    const gasAmount = gasData?.gas || 0;
+    const gasBalanceBudget = resolveGasBalanceBudget(gasData)
 
     const native_currency = gasData?.token || from?.token
 
@@ -52,8 +53,8 @@ const MinMax = (props: MinMaxProps) => {
     }, [fromCurrency.price_in_usd, fromCurrency.decimals]);
 
     let maxAllowedAmount: number = useMemo(() => {
-        return resolveMaxAllowedAmount({ fromCurrency, limitsMaxAmount, walletBalance, gasAmount, native_currency, depositMethod, fallbackAmount }) || 0;
-    }, [fromCurrency, limitsMaxAmount, walletBalance, gasAmount, native_currency, depositMethod, fallbackAmount])
+        return resolveMaxAllowedAmount({ fromCurrency, limitsMaxAmount, walletBalance, gasBalanceBudget, native_currency, depositMethod }) || 0;
+    }, [fromCurrency, limitsMaxAmount, walletBalance, gasBalanceBudget, native_currency, depositMethod])
 
     const minAmount = useMemo(() => {
         if (walletBalance && walletBalance.amount !== undefined && limitsMinAmount !== undefined && depositMethod === 'wallet') {
@@ -102,6 +103,8 @@ const MinMax = (props: MinMaxProps) => {
 
     const minUsdFormatted = minIsFromLimits && limitsMinAmountInUsd != undefined ? ceilUsd(limitsMinAmountInUsd) : undefined;
     const maxUsdFormatted = maxIsFromLimits && limitsMaxAmountInUsd != undefined ? floorUsd(limitsMaxAmountInUsd) : undefined;
+    const maxRequiresGasData = depositMethod === 'wallet' && shouldPayGasWithTheToken
+    const maxIsDisabled = maxValue <= 0 || (maxRequiresGasData && (isGasLoading || !!gasError || !gasData))
 
     const handleSetMinAmount = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault()
@@ -118,6 +121,7 @@ const MinMax = (props: MinMaxProps) => {
     const handleSetMaxAmount = async (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault()
         e.stopPropagation()
+        if (maxIsDisabled) return
         handleSetValue(maxValue.toString(), maxUsdFormatted)
     }
 
@@ -147,6 +151,7 @@ const MinMax = (props: MinMaxProps) => {
                         label="Max"
                         onMouseEnter={() => onActionHover(maxValue, maxUsdFormatted)}
                         onClick={handleSetMaxAmount}
+                        disabled={maxIsDisabled}
                     />
                 </TooltipTrigger>
                 {showMaxTooltip ? <TooltipContent className="pointer-events-none w-80 grow p-2 border-none! bg-secondary-300! text-xs rounded-xl!" side="top" align="start" alignOffset={-10}>

--- a/packages/widget/core/src/components/Input/Amount/helpers.ts
+++ b/packages/widget/core/src/components/Input/Amount/helpers.ts
@@ -5,25 +5,24 @@ import { Token } from "@layerswap/widget-types";
 type ResoleMaxAllowedAmountProps = {
     limitsMaxAmount: number | undefined
     walletBalance: TokenBalance | undefined
-    gasAmount: number
+    gasBalanceBudget: number
     fromCurrency: Token
     native_currency: Token | undefined
     depositMethod: 'wallet' | 'deposit_address' | undefined
-    fallbackAmount: number
 }
 
 export const resolveMaxAllowedAmount = (props: ResoleMaxAllowedAmountProps) => {
-    const { limitsMaxAmount, walletBalance, gasAmount, fromCurrency, native_currency, depositMethod, fallbackAmount } = props
+    const { limitsMaxAmount, walletBalance, gasBalanceBudget, fromCurrency, native_currency, depositMethod } = props
 
     if (!walletBalance || isNaN(Number(walletBalance.amount)) || depositMethod !== 'wallet')
         return limitsMaxAmount
 
     const shouldPayGasWithTheToken = Number(walletBalance.amount) > 0 && (native_currency?.symbol === fromCurrency?.symbol) || !native_currency
-    const payableAmount = Number(walletBalance.amount) - (gasAmount * 1.02)
+    const payableAmount = Number(walletBalance.amount) - gasBalanceBudget
 
     if (!shouldPayGasWithTheToken)
         return isNaN(Number(walletBalance.amount)) ? 0 : Number(walletBalance.amount)
 
     const res = Number(Number(payableAmount).toFixed(fromCurrency?.decimals))
-    return res <= 0 ? fallbackAmount : res
+    return Math.max(0, res)
 }

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Wallet/Common/buttons.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Wallet/Common/buttons.tsx
@@ -321,17 +321,18 @@ export const SendTransactionButton: FC<SendFromWalletButtonProps> = ({
             });
 
             const walletBalance = balances?.find(b => b?.network === swapBasicData.source_network?.name && b?.token === swapBasicData.source_token?.symbol)
-            if (walletBalance?.isNativeCurrency && gasData?.gas && walletBalance?.amount != null) {
+            const gasFee = gasData?.maxFee ?? gasData?.gas
+            if (walletBalance?.isNativeCurrency && gasFee && walletBalance?.amount != null) {
                 const requestedAmount = Number(swapBasicData.requested_amount)
                 const difference = walletBalance.amount - requestedAmount
-                if (difference >= 0 && difference < 5 * gasData.gas) {
+                if (difference >= 0 && difference < 5 * gasFee) {
                     ErrorHandler({
                         type: 'GasMiscalculation',
                         message: (e as Error)?.message,
                         name: (e as Error)?.name,
                         requestedAmount,
                         walletBalance: walletBalance.amount,
-                        calculatedGas: gasData.gas,
+                        calculatedGas: gasFee,
                         difference,
                         network: swapBasicData.source_network?.name,
                         token: swapBasicData.source_token?.symbol,

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Withdraw.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Withdraw.tsx
@@ -23,6 +23,7 @@ import { RefreshBalanceButton } from '../Form/SecondaryComponents/validationErro
 import { AdjustAmountButton } from '../Form/SecondaryComponents/validationError/AdjustAmountButton';
 import { AnimatePresence, motion } from 'framer-motion';
 import { isDepositAddressSwap } from '@/helpers/swapFlow';
+import { resolveGasBalanceBudget } from '@/lib/gases/resolveGasBalanceBudget';
 
 const Withdraw: FC<{ type: 'widget' | 'contained', onWalletWithdrawalSuccess?: () => void, onCancelWithdrawal?: () => void, partner?: Partner }> = ({ type, onWalletWithdrawalSuccess, onCancelWithdrawal, partner }) => {
     const { swapBasicData, swapDetails, quote, refuel, quoteIsLoading, quoteError } = useSwapDataState()
@@ -37,10 +38,11 @@ const Withdraw: FC<{ type: 'widget' | 'contained', onWalletWithdrawalSuccess?: (
     const walletBalanceAmount = walletBalance?.amount
     const { gasData } = useSWRGas(selectedSourceAccount?.address, source_network, swapBasicData?.source_token, swapBasicData?.requested_amount)
     const { setFieldValue } = useFormikContext<SwapFormValues>()
+    const gasBalanceBudget = resolveGasBalanceBudget(gasData)
 
     const handleEditAmount = useCallback(() => {
-        if (walletBalanceAmount == null || !gasData?.gas || !swapBasicData) return
-        const maxAmount = walletBalanceAmount - (gasData.gas * 1.02)
+        if (walletBalanceAmount == null || !gasBalanceBudget || !swapBasicData) return
+        const maxAmount = walletBalanceAmount - gasBalanceBudget
         if (maxAmount <= 0) return
 
         const newAmount = truncateDecimals(maxAmount, swapBasicData.source_token?.precision)
@@ -55,7 +57,7 @@ const Withdraw: FC<{ type: 'widget' | 'contained', onWalletWithdrawalSuccess?: (
             refuel: !!refuel,
             depositMethod: swapBasicData.use_deposit_address ? 'deposit_address' : 'wallet',
         })
-    }, [walletBalanceAmount, gasData?.gas, swapBasicData, refuel, setFieldValue, setSubmitedFormValues])
+    }, [walletBalanceAmount, gasBalanceBudget, swapBasicData, refuel, setFieldValue, setSubmitedFormValues])
 
     let withdraw: {
         content?: JSX.Element | JSX.Element[],

--- a/packages/widget/core/src/lib/gases/resolveGasBalanceBudget.ts
+++ b/packages/widget/core/src/lib/gases/resolveGasBalanceBudget.ts
@@ -1,0 +1,15 @@
+import type { GasWithToken } from '@layerswap/widget-types'
+
+const GAS_FEE_SAFETY_MULTIPLIER = 1.02
+
+/**
+ * Amount of the native token that must not be included in a MAX transfer.
+ * Fee volatility and protocol-level account reserves are deliberately modeled
+ * separately, so a reserve is never inflated as if it were a gas estimate.
+ */
+export const resolveGasBalanceBudget = (gasData?: GasWithToken) => {
+    if (!gasData) return 0
+
+    const maximumFee = gasData.maxFee ?? gasData.gas
+    return (maximumFee * GAS_FEE_SAFETY_MULTIPLIER) + (gasData.balanceReserve ?? 0)
+}

--- a/packages/widget/core/src/lib/gases/useOutOfGas.ts
+++ b/packages/widget/core/src/lib/gases/useOutOfGas.ts
@@ -1,6 +1,7 @@
 import { TokenBalance } from "@layerswap/widget-types";
 import { Network, Token } from "@layerswap/widget-types";
 import useSWRGas from "./useSWRGas"
+import { resolveGasBalanceBudget } from "./resolveGasBalanceBudget"
 
 interface UseOutOfGasParams {
     address: string | undefined
@@ -32,9 +33,10 @@ const useOutOfGas = ({
     }
 
     const numAmount = Number(amount)
-    const totalNeeded = numAmount + gasData.gas
+    const gasBalanceBudget = resolveGasBalanceBudget(gasData)
+    const totalNeeded = numAmount + gasBalanceBudget
     const balanceCoversAmount = numAmount <= balance
-    const balanceExceedsMaxWithGas = balance > (maxAllowedAmount + gasData.gas)
+    const balanceExceedsMaxWithGas = balance > (maxAllowedAmount + gasBalanceBudget)
     const balanceAboveMin = balance > minAllowedAmount
 
     const outOfGas = totalNeeded > balance

--- a/packages/widget/types/src/resolvers/gas.ts
+++ b/packages/widget/types/src/resolvers/gas.ts
@@ -7,6 +7,11 @@ export interface GasProvider {
 }
 
 export type GasWithToken = {
+    /** Expected fee in the native fee token. */
     gas: number,
+    /** Maximum fee reserved for affordability checks, when it differs from the expected fee. */
+    maxFee?: number,
+    /** Native-token balance that must remain after the transaction because of chain/account rules. */
+    balanceReserve?: number,
     token: Token
 }


### PR DESCRIPTION
## Summary

- add a reusable EVM gas-policy registry and keep the transaction builder chain-agnostic
- calculate Monad expected and maximum fees from the signed gas limit with the documented 7.5% margin
- detect EIP-7702 delegated accounts and include Monad’s 10 MON reserve in MAX affordability
- use one shared balance budget across MAX, out-of-gas validation, and amount adjustment
- build native and ERC-20 transaction value correctly

## Testing

- pnpm --filter @layerswap/wallet-evm test
- pnpm --filter @layerswap/widget-types check:types
- pnpm --filter @layerswap/widget check:types
- pnpm --filter @layerswap/widget build:esm+types
- git diff --check

## Documentation

- https://docs.monad.xyz/developer-essentials/wallet-developers
- https://docs.monad.xyz/developer-essentials/gas-pricing
- https://docs.monad.xyz/developer-essentials/reserve-balance