### PR TITLE
Persist swap route history for suggestions, resolves BAB-198

### DIFF
--- a/packages/widget/core/package.json
+++ b/packages/widget/core/package.json
@@ -37,7 +37,8 @@
     "build:esm+types": "tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types && tsc-alias -p tsconfig.json --outDir ./dist/esm && tsc-alias -p tsconfig.json --outDir ./dist/types",
     "check:types": "tsc --noEmit",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
-    "dev": "tsc-watch -p tsconfig.json --outDir ./dist/esm --onSuccess \"tsc-alias -p tsconfig.json --outDir ./dist/esm\""
+    "dev": "tsc-watch -p tsconfig.json --outDir ./dist/esm --onSuccess \"tsc-alias -p tsconfig.json --outDir ./dist/esm\"",
+    "test": "vitest run"
   },
   "author": "Layerswap",
   "homepage": "https://github.com/layerswap/layerswapapp",
@@ -105,12 +106,14 @@
     "@types/react": "catalog:",
     "chromatic": "^6.24.1",
     "esbuild-plugin-path-alias": "^1.0.7",
+    "fake-indexeddb": "^6.2.5",
     "postcss": "^8.5.10",
     "postcss-cli": "^11.0.1",
     "postcss-prefixwrap": "^1.55.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "tailwindcss": "^4.0.15",
+    "vitest": "^3.0.9",
     "zustand": "catalog:"
   },
   "engines": {

--- a/packages/widget/core/src/components/Input/RoutePicker/FlatContent.tsx
+++ b/packages/widget/core/src/components/Input/RoutePicker/FlatContent.tsx
@@ -13,6 +13,7 @@ import ConnectWalletButton from "@/components/Common/ConnectWalletButton";
 import { CurrencySelectItemDisplay } from "./Routes";
 import { SelectItem } from "@/components/Select/Selector/SelectItem";
 import clsx from "clsx";
+import { useSwapRouteRecency } from "@/stores/swapRouteHistoryStore";
 
 type Props = {
     routes: NetworkRoute[];
@@ -48,6 +49,7 @@ export const FlatContent: FC<Props> = ({
     const [isScrolling, setIsScrolling] = useState(false);
     const scrollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
     const recentRoutes = useRecentNetworksStore(s => s.recentRoutes);
+    const swapRecency = useSwapRouteRecency();
     const { wallets } = useWallet();
     const { shouldFocus } = useSelectorState();
 
@@ -55,12 +57,12 @@ export const FlatContent: FC<Props> = ({
         const flattened = extractTokenElementsAsSuggested(routes).filter(
             e => e.route.token.status === "active"
         );
-        const sorted = flattened.sort(sortSuggestedTokenElements(direction, balances, recentRoutes));
+        const sorted = flattened.sort(sortSuggestedTokenElements(direction, balances, recentRoutes, swapRecency));
         if (onlyWithBalance) {
             return sorted.filter(e => getTokenElementBalanceAmount(e, balances) > 0);
         }
         return sorted;
-    }, [routes, balances, direction, recentRoutes, onlyWithBalance]);
+    }, [routes, balances, direction, recentRoutes, swapRecency, onlyWithBalance]);
 
     const showSkeletons = balancesLoading && items.length === 0 && direction === "from";
     const showEmptyState = !!emptyState && !showSkeletons && !balancesLoading && items.length === 0;

--- a/packages/widget/core/src/components/Pages/Deposit/DestinationSelector.tsx
+++ b/packages/widget/core/src/components/Pages/Deposit/DestinationSelector.tsx
@@ -9,6 +9,7 @@ import { useRouteSortingStore } from "@/stores/routeSortingStore";
 import useDepositAddressDestinations from "@/hooks/useDepositAddressDestinations";
 import { SwapFormValues } from "@/components/Pages/Swap/Form/SwapFormValues";
 import { NetworkRoute } from "@layerswap/widget-types";
+import { useSwapRouteRecency } from "@/stores/swapRouteHistoryStore";
 
 type Props = {
     /** When true, render a static (non-interactive) badge — the destination is
@@ -24,6 +25,7 @@ const DestinationSelector: FC<Props> = ({ locked }) => {
     const [searchQuery, setSearchQuery] = useState("");
     const sortingOption = useRouteSortingStore((s) => s.sortingOption);
     const routesHistory = useRecentNetworksStore((state) => state.recentRoutes);
+    const swapRecency = useSwapRouteRecency();
 
     const { data: destinationRoutesData } = useDepositAddressDestinations({ enabled: !locked });
     const isLoading = !locked && destinationRoutesData === undefined;
@@ -45,6 +47,7 @@ const DestinationSelector: FC<Props> = ({ locked }) => {
             balances: null,
             groupBy: "token",
             recents: routesHistory,
+            swapRecency,
             balancesLoaded: false,
             search: searchQuery,
             suggestionsLimit: 4,
@@ -52,7 +55,7 @@ const DestinationSelector: FC<Props> = ({ locked }) => {
             skipBalanceGate: true,
             hideSuggestions: true,
         });
-    }, [availableRoutes, searchQuery, routesHistory, sortingOption]);
+    }, [availableRoutes, searchQuery, routesHistory, swapRecency, sortingOption]);
 
     // Pre-populate the highest-ranked destination so downstream sub-flows have
     // something to use when the dropdown is enabled and no destination is set.

--- a/packages/widget/core/src/components/Pages/Deposit/depositPrefetchContext.tsx
+++ b/packages/widget/core/src/components/Pages/Deposit/depositPrefetchContext.tsx
@@ -13,6 +13,7 @@ import { useSelectedAccount } from "@/context/swapAccounts";
 import { useCallbacks } from "@/context/callbackProvider";
 import { WalletIsSupportedForSource } from "@/context/swap";
 import { useRecentNetworksStore } from "@/stores/recentRoutesStore";
+import { recordSwapRouteHistory } from "@/stores/swapRouteHistoryStore";
 import { useContractAddressStore } from "@/stores/contractAddressStore";
 import { Address } from "@/lib/address/Address";
 import { useDepositSelection } from "./depositSelectionContext";
@@ -206,6 +207,7 @@ export function DepositPrefetchProvider({ children }: { children: ReactNode }) {
                     from: { network: swap.swap.source_network.name, token: swap.swap.source_token.symbol },
                     to: { network: swap.swap.destination_network.name, token: swap.swap.destination_token.symbol },
                 });
+                void recordSwapRouteHistory(swap);
             }
         }
         if (values) {

--- a/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/PayFromPicker.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/PayFromPicker.tsx
@@ -10,6 +10,7 @@ import { useRouteSortingStore } from "@/stores/routeSortingStore";
 import useSuggestionsLimit from "@/hooks/useSuggestionsLimit";
 import useDepositAddressAvailableRoutes from "@/hooks/useDepositAddressAvailableRoutes";
 import PickerTriggerContent from "@/components/Pages/Deposit/_shared/PickerTriggerContent";
+import { useSwapRouteRecency } from "@/stores/swapRouteHistoryStore";
 
 type PayFromPickerProps = {
     selectedSource: { network: NetworkRoute; token: NetworkRouteToken } | null;
@@ -25,6 +26,7 @@ const PayFromPicker: FC<PayFromPickerProps> = ({ selectedSource, onSourceChange,
     const { suggestionsLimit } = useSuggestionsLimit({ hasWallet: wallets.length > 0 });
     const sortingOption = useRouteSortingStore((s) => s.sortingOption);
     const routesHistory = useRecentNetworksStore(state => state.recentRoutes);
+    const swapRecency = useSwapRouteRecency();
 
     const { availableRoutes } = useDepositAddressAvailableRoutes(destinationNetwork, destinationToken);
 
@@ -35,6 +37,7 @@ const PayFromPicker: FC<PayFromPickerProps> = ({ selectedSource, onSourceChange,
             balances: null,
             groupBy: 'token',
             recents: routesHistory,
+            swapRecency,
             balancesLoaded: false,
             search: searchQuery,
             suggestionsLimit,
@@ -42,7 +45,7 @@ const PayFromPicker: FC<PayFromPickerProps> = ({ selectedSource, onSourceChange,
             skipBalanceGate: true,
             hideSuggestions: true,
         });
-    }, [availableRoutes, searchQuery, routesHistory, suggestionsLimit, sortingOption]);
+    }, [availableRoutes, searchQuery, routesHistory, swapRecency, suggestionsLimit, sortingOption]);
 
     // Disable until the destination resolves a non-empty source list.
     const hasOptions = availableRoutes.length > 0;

--- a/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/ReceivePicker.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/ReceivePicker.tsx
@@ -10,6 +10,7 @@ import { useRecentNetworksStore } from "@/stores/recentRoutesStore";
 import { useRouteSortingStore } from "@/stores/routeSortingStore";
 import useSuggestionsLimit from "@/hooks/useSuggestionsLimit";
 import DestinationWalletPicker from "./DestinationWalletPicker";
+import { useSwapRouteRecency } from "@/stores/swapRouteHistoryStore";
 
 type ReceivePickerProps = {
     selectedDestination: { network: NetworkRoute; token: NetworkRouteToken } | null;
@@ -40,6 +41,7 @@ const ReceivePicker: FC<ReceivePickerProps> = ({
     const { suggestionsLimit } = useSuggestionsLimit({ hasWallet: wallets.length > 0 });
     const sortingOption = useRouteSortingStore((s) => s.sortingOption);
     const routesHistory = useRecentNetworksStore(state => state.recentRoutes);
+    const swapRecency = useSwapRouteRecency();
 
     // Skip the network fetch entirely when the caller supplies a fixed route set.
     const { data: destinationRoutesData } = useDepositAddressDestinations({ enabled: !routes });
@@ -59,6 +61,7 @@ const ReceivePicker: FC<ReceivePickerProps> = ({
             balances: null,
             groupBy: 'token',
             recents: routesHistory,
+            swapRecency,
             balancesLoaded: false,
             search: searchQuery,
             suggestionsLimit,
@@ -66,7 +69,7 @@ const ReceivePicker: FC<ReceivePickerProps> = ({
             skipBalanceGate: true,
             hideSuggestions: true,
         });
-    }, [availableRoutes, searchQuery, routesHistory, suggestionsLimit, sortingOption]);
+    }, [availableRoutes, searchQuery, routesHistory, swapRecency, suggestionsLimit, sortingOption]);
 
     const hasMultipleOptions = availableRoutes.length > 1 || availableRoutes.some(r => r.tokens.length > 1);
 

--- a/packages/widget/core/src/context/swap.tsx
+++ b/packages/widget/core/src/context/swap.tsx
@@ -28,6 +28,7 @@ import { buildCreateSwapParamsForExtendedRoute } from '@/lib/extendedRoutes/tran
 import { useExtendedRoutesStore } from '@/stores/extendedRoutesStore';
 import { isDepositAddressFlow, isDepositAddressSwap } from '@/helpers/swapFlow';
 import { resolveSwapPollingInterval, SWAP_POLL_DEDUPE_MS } from '@/lib/swapPollingPolicy';
+import { recordSwapRouteHistory } from '@/stores/swapRouteHistoryStore';
 
 export const SwapDataStateContext = createContext<SwapContextData | null>(null);
 
@@ -363,6 +364,10 @@ export function SwapDataProvider({ children, initialSwapData }: { children: Reac
         updateRecentTokens({
             from: !fromExchange ? { network: from.name, token: fromCurrency.symbol } : undefined,
             to: { network: to.name, token: toCurrency.symbol }
+        });
+        void recordSwapRouteHistory(swap, {
+            sourceRoute: fromExchange ? null : { network: from.name, token: fromCurrency.symbol },
+            destinationRoute: { network: to.name, token: toCurrency.symbol },
         });
 
 

--- a/packages/widget/core/src/helpers/routeUtils.ts
+++ b/packages/widget/core/src/helpers/routeUtils.ts
@@ -3,6 +3,7 @@ import { NetworkBalance } from "@layerswap/widget-types";
 import { NetworkTokenElement } from "../Models/Route";
 import { RoutesHistory } from "@/stores/recentRoutesStore";
 import { SwapDirection } from "@/components/Pages/Swap/Form/SwapFormValues";
+import { getRouteRecency, type SwapRouteRecency } from "@/stores/swapRouteHistoryStore";
 
 /**
  * Pure route-sorting utilities shared by `useFormRoutes` and the flat
@@ -13,12 +14,24 @@ import { SwapDirection } from "@/components/Pages/Swap/Form/SwapFormValues";
 export const extractTokenElementsAsSuggested = (routes: NetworkRoute[]): NetworkTokenElement[] =>
     routes.flatMap(route => (route.tokens || []).map(token => ({ type: 'suggested_token', route: { token, route } })))
 
-export const sortSuggestedTokenElements = (direction: SwapDirection, balances: Record<string, NetworkBalance> | null, routesHistory: RoutesHistory) => (a: NetworkTokenElement, b: NetworkTokenElement) => {
+export const sortSuggestedTokenElements = (
+    direction: SwapDirection,
+    balances: Record<string, NetworkBalance> | null,
+    routesHistory: RoutesHistory,
+    swapRecency?: SwapRouteRecency,
+) => (a: NetworkTokenElement, b: NetworkTokenElement) => {
     if (direction === "from" && balances) {
         const a_balance = getNetworkTokenElementBalance(a, balances)
         const b_balance = getNetworkTokenElementBalance(b, balances)
         if (a_balance !== b_balance) {
             return b_balance - a_balance
+        }
+    }
+    if (swapRecency) {
+        const a_recency = getRouteRecency(swapRecency, direction, a.route.route.name, a.route.token.symbol)
+        const b_recency = getRouteRecency(swapRecency, direction, b.route.route.name, b.route.token.symbol)
+        if (a_recency !== b_recency) {
+            return b_recency - a_recency
         }
     }
     if (routesHistory) {

--- a/packages/widget/core/src/hooks/useFormRoutes.ts
+++ b/packages/widget/core/src/hooks/useFormRoutes.ts
@@ -18,6 +18,7 @@ import { getTotalBalanceInUSD } from "../helpers/balanceHelper";
 import { SortingOption, useRouteSortingStore } from "@/stores/routeSortingStore";
 import { extractTokenElementsAsSuggested, sortSuggestedTokenElements } from "../helpers/routeUtils";
 import { isExtendedSourceNetwork, mergeExtendedSourceRoutes } from "@/lib/extendedRoutes/registry";
+import { useSwapRouteRecency, type SwapRouteRecency } from "@/stores/swapRouteHistoryStore";
 
 type Props = {
     direction: SwapDirection;
@@ -37,6 +38,7 @@ export default function useFormRoutes({ direction, values }: Props, search?: str
     const sortingOption = useRouteSortingStore((s) => s.sortingOption)
     const { balances, partialPublished, isLoading } = useAllWithdrawalBalances();
     const routesHistory = useRecentNetworksStore(state => state.recentRoutes)
+    const swapRecency = useSwapRouteRecency()
     const loadingSuggestions = useMemo(() => {
         return !partialPublished && isLoading && direction === "from"
     }, [isLoading, direction, partialPublished])
@@ -57,12 +59,13 @@ export default function useFormRoutes({ direction, values }: Props, search?: str
             balances,
             groupBy: groupByToken ? "token" : "network",
             recents: routesHistory,
+            swapRecency,
             balancesLoaded: loadingSuggestions,
             search,
             suggestionsLimit,
             sortingOption
         }),
-        [filteredRoutes, balances, direction, search, groupByToken, routesHistory, loadingSuggestions, suggestionsLimit, sortingOption]);
+        [filteredRoutes, balances, direction, search, groupByToken, routesHistory, swapRecency, loadingSuggestions, suggestionsLimit, sortingOption]);
 
     const exchanges = useMemo(() => {
         return groupExchanges(exchangesRoutes, search, direction, { lockFrom, from, lockTo, to });
@@ -564,9 +567,9 @@ function sortTokenItemsByRelevance(
     });
 }
 
-function resolveSearch(routes: NetworkRoute[], search: string, direction: SwapDirection, balances: Record<string, NetworkBalance> | null, routesHistory: RoutesHistory): RowElement[] {
+function resolveSearch(routes: NetworkRoute[], search: string, direction: SwapDirection, balances: Record<string, NetworkBalance> | null, routesHistory: RoutesHistory, swapRecency?: SwapRouteRecency): RowElement[] {
     const matchedNetworks = searchInNetworks(routes, search, direction, balances)
-    const matchedTokens = searchInTokens(routes, search).sort(sortSuggestedTokenElements(direction, balances, routesHistory))
+    const matchedTokens = searchInTokens(routes, search).sort(sortSuggestedTokenElements(direction, balances, routesHistory, swapRecency))
     return [
         ...(matchedNetworks.length ? [resolveTitle('Networks'), ...matchedNetworks] : []),
         ...(matchedTokens.length ? [resolveTitle('Tokens'), ...matchedTokens] : [])
@@ -626,6 +629,7 @@ export type GroupRoutesProps = {
     balances: Record<string, NetworkBalance> | null;
     groupBy: 'token' | 'network';
     recents: RoutesHistory;
+    swapRecency?: SwapRouteRecency;
     balancesLoaded: boolean;
     search?: string;
     suggestionsLimit?: number;
@@ -637,17 +641,17 @@ export type GroupRoutesProps = {
 }
 
 export function groupRoutes(
-    { routes, direction, balances, groupBy, recents, balancesLoaded, search, suggestionsLimit = 4, sortingOption = SortingOption.RELEVANCE, skipBalanceGate = false, hideSuggestions = false }: GroupRoutesProps
+    { routes, direction, balances, groupBy, recents, swapRecency, balancesLoaded, search, suggestionsLimit = 4, sortingOption = SortingOption.RELEVANCE, skipBalanceGate = false, hideSuggestions = false }: GroupRoutesProps
 ): RowElement[] {
 
     if (search) {
-        return resolveSearch(routes, search, direction, balances, recents)
+        return resolveSearch(routes, search, direction, balances, recents, swapRecency)
     }
 
     // Suggestions always use relevance-based sorting (unchanged)
     const suggestedRoutes = hideSuggestions
         ? []
-        : getSuggestedRoutes(routes, balances, recents, direction, balancesLoaded, suggestionsLimit, skipBalanceGate)
+        : getSuggestedRoutes(routes, balances, recents, direction, balancesLoaded, suggestionsLimit, skipBalanceGate, swapRecency)
 
     // Apply custom sorting ONLY to "All Networks/All Tokens" section
     if (groupBy === "token") {
@@ -802,7 +806,7 @@ function useExchangeRoutes({ values }: Props) {
     return { exchangesRoutes: res, isLoading }
 }
 
-function getSuggestedRoutes(routes: NetworkRoute[], balances: Record<string, NetworkBalance> | null, routesHistory: RoutesHistory, direction: SwapDirection, balancesLoading: boolean, limit: number = 4, skipBalanceGate: boolean = false): (NetworkTokenElement | TokenSceletonElement)[] {
+function getSuggestedRoutes(routes: NetworkRoute[], balances: Record<string, NetworkBalance> | null, routesHistory: RoutesHistory, direction: SwapDirection, balancesLoading: boolean, limit: number = 4, skipBalanceGate: boolean = false, swapRecency?: SwapRouteRecency): (NetworkTokenElement | TokenSceletonElement)[] {
     // Ensure minimum of 4 suggestions
     const effectiveLimit = Math.max(4, limit);
 
@@ -814,7 +818,7 @@ function getSuggestedRoutes(routes: NetworkRoute[], balances: Record<string, Net
     }
 
     const tokenElements = extractTokenElementsAsSuggested(routes).filter(t => t.route.token.status === "active")
-    const sorted = tokenElements.sort(sortSuggestedTokenElements(direction, balances, routesHistory))
+    const sorted = tokenElements.sort(sortSuggestedTokenElements(direction, balances, routesHistory, swapRecency))
     return sorted.slice(0, effectiveLimit)
 }
 

--- a/packages/widget/core/src/hooks/useSwapHistoryData.ts
+++ b/packages/widget/core/src/hooks/useSwapHistoryData.ts
@@ -6,6 +6,7 @@ import { ApiResponse } from '@/Models/ApiResponse'
 import { useSwapTransactionStore } from '@/stores/swapTransactionStore'
 import { useExtendedSourceSkin } from './useExtendedSourceSkin'
 import { Address } from '@/lib/address/Address'
+import { recordFetchedSwapRouteHistory } from '@/stores/swapRouteHistoryStore'
 
 export function useSwapHistoryData(addresses?: string[], networks?: string[]) {
     const [revalidateAll, setRevalidateAll] = useState(false)
@@ -177,6 +178,13 @@ export function useSwapHistoryData(addresses?: string[], networks?: string[]) {
         () => ({ ...mergedCompleted, swaps: skinnedCompletedSwaps }),
         [mergedCompleted, skinnedCompletedSwaps],
     )
+
+    useEffect(() => {
+        void recordFetchedSwapRouteHistory([
+            ...skinnedPendingSwaps,
+            ...skinnedCompletedSwaps,
+        ])
+    }, [skinnedPendingSwaps, skinnedCompletedSwaps])
 
     return {
         pendingDeposit: skinnedPendingDeposit,

--- a/packages/widget/core/src/lib/swapRouteHistoryDb.ts
+++ b/packages/widget/core/src/lib/swapRouteHistoryDb.ts
@@ -1,0 +1,170 @@
+export type SwapRouteIdentity = {
+    network: string;
+    token: string;
+}
+
+export type PersistedSwapRoute = {
+    swapId: string;
+    environment: string;
+    createdAt: number;
+    sourceRoute?: SwapRouteIdentity;
+    destinationRoute: SwapRouteIdentity;
+}
+
+const DATABASE_NAME = 'layerswap-widget-swap-history'
+const DATABASE_VERSION = 1
+const STORE_NAME = 'swap-route-history'
+const ENVIRONMENT_INDEX = 'environment'
+
+export const MAX_PERSISTED_SWAP_ROUTES = 500
+
+type RepositoryOptions = {
+    indexedDb?: IDBFactory;
+    databaseName?: string;
+}
+
+export type SwapRouteHistoryRepository = {
+    getRecent: (environment: string) => Promise<PersistedSwapRoute[]>;
+    upsert: (records: PersistedSwapRoute[]) => Promise<void>;
+    close: () => void;
+}
+
+/**
+ * Small native IndexedDB repository. All failures are deliberately contained:
+ * route history improves suggestions, but must never prevent the widget from
+ * rendering or creating a swap.
+ */
+export function createSwapRouteHistoryRepository(options: RepositoryOptions = {}): SwapRouteHistoryRepository {
+    const indexedDb = options.indexedDb ?? (typeof indexedDB === 'undefined' ? undefined : indexedDB)
+    const databaseName = options.databaseName ?? DATABASE_NAME
+    let databasePromise: Promise<IDBDatabase | null> | undefined
+    let database: IDBDatabase | undefined
+
+    const openDatabase = () => {
+        if (!indexedDb) return Promise.resolve(null)
+        if (databasePromise) return databasePromise
+
+        databasePromise = new Promise<IDBDatabase | null>((resolve) => {
+            let settled = false
+            const request = indexedDb.open(databaseName, DATABASE_VERSION)
+
+            request.onupgradeneeded = () => {
+                const db = request.result
+                if (db.objectStoreNames.contains(STORE_NAME)) return
+                const store = db.createObjectStore(STORE_NAME, { keyPath: ['environment', 'swapId'] })
+                store.createIndex(ENVIRONMENT_INDEX, 'environment', { unique: false })
+            }
+            request.onsuccess = () => {
+                if (settled) {
+                    request.result.close()
+                    return
+                }
+                settled = true
+                database = request.result
+                database.onversionchange = () => {
+                    database?.close()
+                    database = undefined
+                    databasePromise = undefined
+                }
+                resolve(database)
+            }
+            request.onerror = () => {
+                if (settled) return
+                settled = true
+                resolve(null)
+            }
+            request.onblocked = () => {
+                if (settled) return
+                settled = true
+                resolve(null)
+            }
+        })
+
+        return databasePromise
+    }
+
+    const getRecent = async (environment: string): Promise<PersistedSwapRoute[]> => {
+        try {
+            const db = await openDatabase()
+            if (!db) return []
+
+            const transaction = db.transaction(STORE_NAME, 'readonly')
+            const records = await requestAsPromise<PersistedSwapRoute[]>(
+                transaction.objectStore(STORE_NAME).index(ENVIRONMENT_INDEX).getAll(environment),
+            )
+            await transactionDone(transaction)
+
+            return records
+                .sort(compareNewestFirst)
+                .slice(0, MAX_PERSISTED_SWAP_ROUTES)
+        } catch {
+            return []
+        }
+    }
+
+    const upsert = async (records: PersistedSwapRoute[]): Promise<void> => {
+        if (records.length === 0) return
+
+        try {
+            const db = await openDatabase()
+            if (!db) return
+
+            const transaction = db.transaction(STORE_NAME, 'readwrite')
+            const store = transaction.objectStore(STORE_NAME)
+            for (const record of records) store.put(record)
+            await transactionDone(transaction)
+
+            const environments = new Set(records.map(record => record.environment))
+            await Promise.all([...environments].map(environment => pruneEnvironment(db, environment)))
+        } catch {
+            // Suggestion history is best-effort. Keep the in-memory state usable.
+        }
+    }
+
+    const close = () => {
+        database?.close()
+        database = undefined
+        databasePromise = undefined
+    }
+
+    return { getRecent, upsert, close }
+}
+
+async function pruneEnvironment(db: IDBDatabase, environment: string) {
+    const readTransaction = db.transaction(STORE_NAME, 'readonly')
+    const records = await requestAsPromise<PersistedSwapRoute[]>(
+        readTransaction.objectStore(STORE_NAME).index(ENVIRONMENT_INDEX).getAll(environment),
+    )
+    await transactionDone(readTransaction)
+
+    if (records.length <= MAX_PERSISTED_SWAP_ROUTES) return
+
+    const staleRecords = records
+        .sort(compareNewestFirst)
+        .slice(MAX_PERSISTED_SWAP_ROUTES)
+    const deleteTransaction = db.transaction(STORE_NAME, 'readwrite')
+    const store = deleteTransaction.objectStore(STORE_NAME)
+    for (const record of staleRecords) store.delete([environment, record.swapId])
+    await transactionDone(deleteTransaction)
+}
+
+function compareNewestFirst(a: PersistedSwapRoute, b: PersistedSwapRoute) {
+    return b.createdAt - a.createdAt || a.swapId.localeCompare(b.swapId)
+}
+
+function requestAsPromise<T>(request: IDBRequest<T>) {
+    return new Promise<T>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+    })
+}
+
+function transactionDone(transaction: IDBTransaction) {
+    return new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve()
+        transaction.onerror = () => reject(transaction.error)
+        transaction.onabort = () => reject(transaction.error)
+    })
+}
+
+export const swapRouteHistoryRepository = createSwapRouteHistoryRepository()

--- a/packages/widget/core/src/stores/swapRouteHistoryStore.ts
+++ b/packages/widget/core/src/stores/swapRouteHistoryStore.ts
@@ -1,0 +1,238 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { create } from 'zustand'
+import LayerSwapApiClient, { type SwapResponse } from '@/lib/apiClients/layerSwapApiClient'
+import {
+    MAX_PERSISTED_SWAP_ROUTES,
+    swapRouteHistoryRepository,
+    type PersistedSwapRoute,
+    type SwapRouteHistoryRepository,
+    type SwapRouteIdentity,
+} from '@/lib/swapRouteHistoryDb'
+
+type SwapRouteHistoryState = {
+    environment?: string;
+    hydratedEnvironment?: string;
+    records: PersistedSwapRoute[];
+}
+
+export type SwapRouteRecency = {
+    sourceRoutes: Map<string, number>;
+    destinationRoutes: Map<string, number>;
+}
+
+export type SwapRouteOverrides = {
+    sourceRoute?: SwapRouteIdentity | null;
+    destinationRoute?: SwapRouteIdentity;
+}
+
+const EMPTY_RECORDS: PersistedSwapRoute[] = []
+const hydrationPromises = new Map<string, Promise<void>>()
+
+export const useSwapRouteHistoryStore = create<SwapRouteHistoryState>(() => ({
+    records: EMPTY_RECORDS,
+}))
+
+export function getSwapRouteHistoryEnvironment() {
+    const apiBase = (LayerSwapApiClient.apiBaseEndpoint || 'default').replace(/\/+$/, '')
+    const apiKey = LayerSwapApiClient.apiKey || 'default'
+    return `${apiBase}|${apiKey}`
+}
+
+export function toPersistedSwapRoute(
+    response: SwapResponse,
+    environment: string,
+    overrides: SwapRouteOverrides = {},
+): PersistedSwapRoute | undefined {
+    const swap = response.swap
+    const sourceRoute = Object.prototype.hasOwnProperty.call(overrides, 'sourceRoute')
+        ? overrides.sourceRoute ?? undefined
+        : swap.source_exchange
+            ? undefined
+            : asRouteIdentity(swap.source_network?.name, swap.source_token?.symbol)
+    const destinationRoute = overrides.destinationRoute
+        ?? asRouteIdentity(swap.destination_network?.name, swap.destination_token?.symbol)
+
+    if (!swap.id || !destinationRoute) return undefined
+
+    const parsedCreatedAt = Date.parse(swap.created_date)
+    return {
+        swapId: swap.id,
+        environment,
+        createdAt: Number.isFinite(parsedCreatedAt) ? parsedCreatedAt : Date.now(),
+        sourceRoute,
+        destinationRoute,
+    }
+}
+
+export function mergeSwapRouteHistoryRecords(
+    current: PersistedSwapRoute[],
+    updates: PersistedSwapRoute[],
+): PersistedSwapRoute[] {
+    if (updates.length === 0) return current
+
+    const recordsById = new Map(current.map(record => [record.swapId, record]))
+    for (const record of updates) recordsById.set(record.swapId, record)
+
+    const merged = [...recordsById.values()]
+        .sort((a, b) => b.createdAt - a.createdAt || a.swapId.localeCompare(b.swapId))
+        .slice(0, MAX_PERSISTED_SWAP_ROUTES)
+
+    if (merged.length === current.length && merged.every((record, index) => recordsEqual(record, current[index]))) {
+        return current
+    }
+    return merged
+}
+
+export function buildSwapRouteRecency(records: PersistedSwapRoute[]): SwapRouteRecency {
+    const sourceRoutes = new Map<string, number>()
+    const destinationRoutes = new Map<string, number>()
+
+    for (const record of records) {
+        if (record.sourceRoute) setLatest(sourceRoutes, record.sourceRoute, record.createdAt)
+        setLatest(destinationRoutes, record.destinationRoute, record.createdAt)
+    }
+
+    return { sourceRoutes, destinationRoutes }
+}
+
+export function getRouteRecency(
+    recency: SwapRouteRecency,
+    direction: 'from' | 'to',
+    network: string,
+    token: string,
+) {
+    const index = direction === 'from' ? recency.sourceRoutes : recency.destinationRoutes
+    return index.get(routeKey(network, token)) ?? 0
+}
+
+export function hydrateSwapRouteHistory(
+    environment: string = getSwapRouteHistoryEnvironment(),
+    repository: SwapRouteHistoryRepository = swapRouteHistoryRepository,
+) {
+    const state = useSwapRouteHistoryStore.getState()
+    if (state.hydratedEnvironment === environment) return Promise.resolve()
+
+    if (state.environment !== environment) {
+        useSwapRouteHistoryStore.setState({
+            environment,
+            hydratedEnvironment: undefined,
+            records: EMPTY_RECORDS,
+        })
+    }
+
+    const inFlight = hydrationPromises.get(environment)
+    if (inFlight) return inFlight
+
+    const promise = repository.getRecent(environment)
+        .then(persistedRecords => {
+            const current = useSwapRouteHistoryStore.getState()
+            if (current.environment !== environment) return
+
+            // In-memory records may have been created while IndexedDB was
+            // loading. Apply them last so hydration cannot overwrite them.
+            const records = mergeSwapRouteHistoryRecords(persistedRecords, current.records)
+            useSwapRouteHistoryStore.setState({
+                records,
+                hydratedEnvironment: environment,
+            })
+        })
+        .catch(() => {
+            const current = useSwapRouteHistoryStore.getState()
+            if (current.environment === environment) {
+                useSwapRouteHistoryStore.setState({ hydratedEnvironment: environment })
+            }
+        })
+        .finally(() => {
+            hydrationPromises.delete(environment)
+        })
+
+    hydrationPromises.set(environment, promise)
+    return promise
+}
+
+export function recordSwapRouteHistory(
+    response: SwapResponse,
+    overrides?: SwapRouteOverrides,
+    repository: SwapRouteHistoryRepository = swapRouteHistoryRepository,
+) {
+    return recordSwapRoutes([response], overrides ? [overrides] : undefined, repository)
+}
+
+export function recordFetchedSwapRouteHistory(
+    responses: SwapResponse[],
+    repository: SwapRouteHistoryRepository = swapRouteHistoryRepository,
+) {
+    return recordSwapRoutes(responses, undefined, repository)
+}
+
+export function useSwapRouteRecency() {
+    const environment = getSwapRouteHistoryEnvironment()
+    const records = useSwapRouteHistoryStore(state =>
+        state.environment === environment ? state.records : EMPTY_RECORDS,
+    )
+
+    useEffect(() => {
+        void hydrateSwapRouteHistory(environment)
+    }, [environment])
+
+    return useMemo(() => buildSwapRouteRecency(records), [records])
+}
+
+async function recordSwapRoutes(
+    responses: SwapResponse[],
+    overrides: SwapRouteOverrides[] | undefined,
+    repository: SwapRouteHistoryRepository,
+) {
+    if (responses.length === 0) return
+
+    const environment = getSwapRouteHistoryEnvironment()
+    const records = responses
+        .map((response, index) => toPersistedSwapRoute(response, environment, overrides?.[index]))
+        .filter((record): record is PersistedSwapRoute => !!record)
+    if (records.length === 0) return
+
+    const state = useSwapRouteHistoryStore.getState()
+    const currentRecords = state.environment === environment ? state.records : EMPTY_RECORDS
+    const currentById = new Map(currentRecords.map(record => [record.swapId, record]))
+    const changedRecords = records.filter(record => !recordsEqual(record, currentById.get(record.swapId)))
+    if (state.environment === environment && changedRecords.length === 0) return
+
+    const mergedRecords = mergeSwapRouteHistoryRecords(currentRecords, changedRecords)
+
+    useSwapRouteHistoryStore.setState({
+        environment,
+        hydratedEnvironment: state.environment === environment ? state.hydratedEnvironment : undefined,
+        records: mergedRecords,
+    })
+    await repository.upsert(changedRecords)
+}
+
+function asRouteIdentity(network?: string, token?: string): SwapRouteIdentity | undefined {
+    if (!network || !token) return undefined
+    return { network, token }
+}
+
+function routeKey(network: string, token: string) {
+    return `${network}\u0000${token}`
+}
+
+function setLatest(index: Map<string, number>, route: SwapRouteIdentity, createdAt: number) {
+    const key = routeKey(route.network, route.token)
+    const previous = index.get(key) ?? 0
+    if (createdAt > previous) index.set(key, createdAt)
+}
+
+function recordsEqual(a: PersistedSwapRoute, b: PersistedSwapRoute | undefined) {
+    return !!b
+        && a.swapId === b.swapId
+        && a.environment === b.environment
+        && a.createdAt === b.createdAt
+        && routesEqual(a.sourceRoute, b.sourceRoute)
+        && routesEqual(a.destinationRoute, b.destinationRoute)
+}
+
+function routesEqual(a: SwapRouteIdentity | undefined, b: SwapRouteIdentity | undefined) {
+    return a?.network === b?.network && a?.token === b?.token
+}

--- a/packages/widget/core/tests/routeSuggestions.test.ts
+++ b/packages/widget/core/tests/routeSuggestions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import type { NetworkBalance } from '@layerswap/widget-types'
+import type { NetworkTokenElement } from '@/Models/Route'
+import { sortSuggestedTokenElements } from '@/helpers/routeUtils'
+import type { RoutesHistory } from '@/stores/recentRoutesStore'
+import { buildSwapRouteRecency } from '@/stores/swapRouteHistoryStore'
+import type { PersistedSwapRoute } from '@/lib/swapRouteHistoryDb'
+
+function item(network: string, token: string, rank: number): NetworkTokenElement {
+    return {
+        type: 'suggested_token',
+        route: {
+            route: {
+                name: network,
+                display_name: network,
+                tokens: [],
+            },
+            token: {
+                symbol: token,
+                price_in_usd: 1,
+                source_rank: rank,
+                destination_rank: rank,
+            },
+        },
+    } as NetworkTokenElement
+}
+
+function persisted(item: NetworkTokenElement, createdAt: number): PersistedSwapRoute {
+    const route = {
+        network: item.route.route.name,
+        token: item.route.token.symbol,
+    }
+    return {
+        swapId: `${route.network}-${createdAt}`,
+        environment: 'environment',
+        createdAt,
+        sourceRoute: route,
+        destinationRoute: route,
+    }
+}
+
+const emptyHistory: RoutesHistory = {
+    sourceRoutes: {},
+    destinationRoutes: {},
+}
+
+describe('suggestion route sorting', () => {
+    it('keeps source balance ahead of persisted recency', () => {
+        const higherBalance = item('BALANCE', 'AAA', 2)
+        const moreRecent = item('RECENT', 'BBB', 1)
+        const balances = {
+            BALANCE: { balances: [{ token: 'AAA', amount: 10 }] },
+            RECENT: { balances: [{ token: 'BBB', amount: 1 }] },
+        } as Record<string, NetworkBalance>
+        const recency = buildSwapRouteRecency([persisted(moreRecent, 20), persisted(higherBalance, 10)])
+
+        const sorted = [moreRecent, higherBalance].sort(
+            sortSuggestedTokenElements('from', balances, emptyHistory, recency),
+        )
+
+        expect(sorted[0]).toBe(higherBalance)
+    })
+
+    it('keeps persisted recency ahead of recent-route usage', () => {
+        const heavilyUsed = item('USED', 'AAA', 1)
+        const moreRecent = item('RECENT', 'BBB', 2)
+        const history: RoutesHistory = {
+            sourceRoutes: { USED: { AAA: 100 } },
+            destinationRoutes: {},
+        }
+        const recency = buildSwapRouteRecency([persisted(heavilyUsed, 10), persisted(moreRecent, 20)])
+
+        const sorted = [heavilyUsed, moreRecent].sort(
+            sortSuggestedTokenElements('from', null, history, recency),
+        )
+
+        expect(sorted[0]).toBe(moreRecent)
+    })
+
+    it('uses recent-route usage and then API rank when no persisted recency exists', () => {
+        const used = item('USED', 'AAA', 10)
+        const ranked = item('RANKED', 'BBB', 1)
+        const history: RoutesHistory = {
+            sourceRoutes: { USED: { AAA: 2 } },
+            destinationRoutes: {},
+        }
+        const emptyRecency = buildSwapRouteRecency([])
+
+        expect([ranked, used].sort(sortSuggestedTokenElements('from', null, history, emptyRecency))[0]).toBe(used)
+        expect([used, ranked].sort(sortSuggestedTokenElements('from', null, emptyHistory, emptyRecency))[0]).toBe(ranked)
+    })
+
+    it('ignores wallet balances for destination suggestions', () => {
+        const higherBalance = item('BALANCE', 'AAA', 1)
+        const moreRecent = item('RECENT', 'BBB', 2)
+        const balances = {
+            BALANCE: { balances: [{ token: 'AAA', amount: 10 }] },
+            RECENT: { balances: [{ token: 'BBB', amount: 1 }] },
+        } as Record<string, NetworkBalance>
+        const recency = buildSwapRouteRecency([persisted(higherBalance, 10), persisted(moreRecent, 20)])
+
+        const sorted = [higherBalance, moreRecent].sort(
+            sortSuggestedTokenElements('to', balances, emptyHistory, recency),
+        )
+
+        expect(sorted[0]).toBe(moreRecent)
+    })
+})

--- a/packages/widget/core/tests/swapRouteHistoryDb.test.ts
+++ b/packages/widget/core/tests/swapRouteHistoryDb.test.ts
@@ -1,0 +1,64 @@
+import { IDBFactory } from 'fake-indexeddb'
+import { describe, expect, it } from 'vitest'
+import {
+    MAX_PERSISTED_SWAP_ROUTES,
+    createSwapRouteHistoryRepository,
+    type PersistedSwapRoute,
+} from '@/lib/swapRouteHistoryDb'
+
+const route = { network: 'NETWORK', token: 'TOKEN' }
+
+function record(swapId: string, environment: string, createdAt: number): PersistedSwapRoute {
+    return {
+        swapId,
+        environment,
+        createdAt,
+        sourceRoute: route,
+        destinationRoute: route,
+    }
+}
+
+describe('swap route history IndexedDB repository', () => {
+    it('upserts by environment and swap id while keeping environments isolated', async () => {
+        const repository = createSwapRouteHistoryRepository({
+            indexedDb: new IDBFactory(),
+            databaseName: 'swap-history-upsert',
+        })
+
+        await repository.upsert([
+            record('same-id', 'mainnet', 1),
+            record('testnet-id', 'testnet', 2),
+        ])
+        await repository.upsert([record('same-id', 'mainnet', 3)])
+
+        expect(await repository.getRecent('mainnet')).toEqual([record('same-id', 'mainnet', 3)])
+        expect(await repository.getRecent('testnet')).toEqual([record('testnet-id', 'testnet', 2)])
+        repository.close()
+    })
+
+    it('retains only the newest 500 records for an environment', async () => {
+        const repository = createSwapRouteHistoryRepository({
+            indexedDb: new IDBFactory(),
+            databaseName: 'swap-history-retention',
+        })
+        const records = Array.from(
+            { length: MAX_PERSISTED_SWAP_ROUTES + 5 },
+            (_, index) => record(`swap-${index}`, 'mainnet', index),
+        )
+
+        await repository.upsert(records)
+
+        const persisted = await repository.getRecent('mainnet')
+        expect(persisted).toHaveLength(MAX_PERSISTED_SWAP_ROUTES)
+        expect(persisted[0].createdAt).toBe(MAX_PERSISTED_SWAP_ROUTES + 4)
+        expect(persisted.at(-1)?.createdAt).toBe(5)
+        repository.close()
+    })
+
+    it('falls back to an empty no-op repository when IndexedDB is unavailable', async () => {
+        const repository = createSwapRouteHistoryRepository({ databaseName: 'unavailable' })
+
+        await expect(repository.upsert([record('swap', 'mainnet', 1)])).resolves.toBeUndefined()
+        await expect(repository.getRecent('mainnet')).resolves.toEqual([])
+    })
+})

--- a/packages/widget/core/tests/swapRouteHistoryStore.test.ts
+++ b/packages/widget/core/tests/swapRouteHistoryStore.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SwapResponse } from '@/lib/apiClients/layerSwapApiClient'
+import type { PersistedSwapRoute, SwapRouteHistoryRepository } from '@/lib/swapRouteHistoryDb'
+import {
+    buildSwapRouteRecency,
+    getRouteRecency,
+    hydrateSwapRouteHistory,
+    mergeSwapRouteHistoryRecords,
+    toPersistedSwapRoute,
+    useSwapRouteHistoryStore,
+} from '@/stores/swapRouteHistoryStore'
+
+function response(overrides: {
+    id?: string;
+    createdDate?: string;
+    sourceExchange?: boolean;
+    status?: string;
+} = {}): SwapResponse {
+    return {
+        swap: {
+            id: overrides.id ?? 'swap-id',
+            created_date: overrides.createdDate ?? '2026-01-02T03:04:05.000Z',
+            source_network: { name: 'SOURCE' },
+            source_token: { symbol: 'SRC' },
+            source_exchange: overrides.sourceExchange ? { name: 'EXCHANGE' } : undefined,
+            destination_network: { name: 'DESTINATION' },
+            destination_token: { symbol: 'DST' },
+            status: overrides.status ?? 'Completed',
+        },
+    } as SwapResponse
+}
+
+function record(
+    swapId: string,
+    createdAt: number,
+    sourceNetwork: string = 'SOURCE',
+): PersistedSwapRoute {
+    return {
+        swapId,
+        environment: 'environment',
+        createdAt,
+        sourceRoute: { network: sourceNetwork, token: 'SRC' },
+        destinationRoute: { network: 'DESTINATION', token: 'DST' },
+    }
+}
+
+beforeEach(() => {
+    useSwapRouteHistoryStore.setState({
+        environment: undefined,
+        hydratedEnvironment: undefined,
+        records: [],
+    }, true)
+})
+
+describe('compact swap route records', () => {
+    it.each(['PendingDeposit', 'Completed', 'Refunded'])(
+        'extracts routes regardless of the %s status',
+        status => {
+            const persisted = toPersistedSwapRoute(response({ status }), 'environment')
+
+            expect(persisted).toMatchObject({
+                swapId: 'swap-id',
+                environment: 'environment',
+                sourceRoute: { network: 'SOURCE', token: 'SRC' },
+                destinationRoute: { network: 'DESTINATION', token: 'DST' },
+            })
+        },
+    )
+
+    it('omits exchange sources and supports an extended-route identity override', () => {
+        expect(toPersistedSwapRoute(response({ sourceExchange: true }), 'environment')?.sourceRoute).toBeUndefined()
+
+        expect(toPersistedSwapRoute(response(), 'environment', {
+            sourceRoute: { network: 'EXTENDED', token: 'EXT' },
+        })?.sourceRoute).toEqual({ network: 'EXTENDED', token: 'EXT' })
+    })
+
+    it('deduplicates records and indexes the latest use in each direction', () => {
+        const records = mergeSwapRouteHistoryRecords(
+            [record('same-id', 1), record('older', 2, 'OTHER')],
+            [record('same-id', 3)],
+        )
+        const recency = buildSwapRouteRecency(records)
+
+        expect(records).toHaveLength(2)
+        expect(records[0].createdAt).toBe(3)
+        expect(getRouteRecency(recency, 'from', 'SOURCE', 'SRC')).toBe(3)
+        expect(getRouteRecency(recency, 'to', 'DESTINATION', 'DST')).toBe(3)
+    })
+
+    it('does not overwrite an in-memory write that lands during hydration', async () => {
+        let resolveRead: (records: PersistedSwapRoute[]) => void = () => undefined
+        const read = new Promise<PersistedSwapRoute[]>(resolve => {
+            resolveRead = resolve
+        })
+        const repository: SwapRouteHistoryRepository = {
+            getRecent: () => read,
+            upsert: vi.fn().mockResolvedValue(undefined),
+            close: vi.fn(),
+        }
+
+        const hydration = hydrateSwapRouteHistory('environment', repository)
+        useSwapRouteHistoryStore.setState({
+            environment: 'environment',
+            records: [record('same-id', 10, 'IN_MEMORY')],
+        })
+        resolveRead([record('same-id', 1, 'PERSISTED'), record('older', 2, 'OTHER')])
+        await hydration
+
+        const state = useSwapRouteHistoryStore.getState()
+        expect(state.hydratedEnvironment).toBe('environment')
+        expect(state.records.find(item => item.swapId === 'same-id')?.sourceRoute?.network).toBe('IN_MEMORY')
+        expect(state.records.map(item => item.swapId)).toContain('older')
+    })
+})

--- a/packages/widget/core/vitest.config.ts
+++ b/packages/widget/core/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
+    test: {
+        environment: 'node',
+        include: ['tests/**/*.test.ts'],
+    },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,13 +729,13 @@ importers:
     dependencies:
       '@fuel-ts/account':
         specifier: ^0.101.3
-        version: 0.101.3
+        version: 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/address':
         specifier: ^0.101.3
-        version: 0.101.3
+        version: 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       fuels:
         specifier: ^0.101.3
-        version: 0.101.3
+        version: 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       json-rpc-2.0:
         specifier: 1.7.0
         version: 1.7.0
@@ -1139,6 +1139,9 @@ importers:
       esbuild-plugin-path-alias:
         specifier: ^1.0.7
         version: 1.0.7(esbuild@0.25.3)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       postcss:
         specifier: '>=8.5.18 <9'
         version: 8.5.24
@@ -1157,6 +1160,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.15
         version: 4.0.15
+      vitest:
+        specifier: ^3.0.9
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)
       zustand:
         specifier: 'catalog:'
         version: 4.5.7(@types/react@19.2.3)(immer@11.1.15)(react@19.2.3)
@@ -2055,6 +2061,9 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
     engines: {node: '>=10.0'}
@@ -2411,6 +2420,12 @@ packages:
   '@msgpack/msgpack@3.1.2':
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3922,6 +3937,131 @@ packages:
   '@reown/appkit@1.7.8':
     resolution: {integrity: sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==}
 
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding-darwin-arm64@1.7.12':
     resolution: {integrity: sha512-rbFprJaJiqrmfy8SHth8EsoRS0wg4bXcucwj9NiMzpGFq14Opw8c04iQ6H9BECYzgmN0PKZ9rh41LdVvhdZe4A==}
     cpu: [arm64]
@@ -5126,6 +5266,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/express-serve-static-core@4.19.9':
     resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
 
@@ -5480,6 +5623,38 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@3.0.9':
+    resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
+
+  '@vitest/mocker@3.0.9':
+    resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.0.9':
+    resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.0.9':
+    resolution: {integrity: sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==}
+
+  '@vitest/snapshot@3.0.9':
+    resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
+
+  '@vitest/spy@3.0.9':
+    resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
+
+  '@vitest/utils@3.0.9':
+    resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
+
   '@wagmi/connectors@5.7.7':
     resolution: {integrity: sha512-hveKxuR35ZQQyteLo7aiN/TBVECYKVbLNTYGGgqzTNHJ8vVoblTP9PwPrRPGOPi5ji8raYSFWShxNK7QpGL+Kg==}
     peerDependencies:
@@ -5824,6 +5999,10 @@ packages:
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -6090,6 +6269,10 @@ packages:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
@@ -6138,6 +6321,10 @@ packages:
     resolution: {integrity: sha512-vIwORDd/WyB8Nc23o2zNN5RrtFGlR6Fca61TtjkUXueI3Jf2DOZDl1zsshvBntZ3wZHBM9ztjnkXSmzQDaq3WA==}
     engines: {node: '>=20'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
     engines: {node: '>=8'}
@@ -6152,6 +6339,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -6488,6 +6679,10 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
 
@@ -6694,6 +6889,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -6856,6 +7054,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -6955,6 +7156,10 @@ packages:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
@@ -6969,6 +7174,10 @@ packages:
   eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -8021,6 +8230,9 @@ packages:
   lossless-json@4.3.0:
     resolution: {integrity: sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -8035,6 +8247,9 @@ packages:
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
@@ -8629,6 +8844,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
 
@@ -8645,6 +8867,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -9219,6 +9445,11 @@ packages:
     resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
     hasBin: true
 
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rpc-websockets@9.3.2:
     resolution: {integrity: sha512-VuW2xJDnl1k8n8kjbdRSWawPRkwaVqUQNjE1TdeTawf0y0abGhtVJFTXCLfgpgGDBkO/Fj6kny8Dc/nvOW78MA==}
 
@@ -9407,6 +9638,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -9499,6 +9733,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   starknet@8.9.2:
     resolution: {integrity: sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==}
     engines: {node: '>=22'}
@@ -9515,6 +9752,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -9722,12 +9962,34 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -10159,6 +10421,79 @@ packages:
       typescript:
         optional: true
 
+  vite-node@3.0.9:
+    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: 2.8.3
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.0.9:
+    resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.9
+      '@vitest/ui': 3.0.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
@@ -10264,6 +10599,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wif@5.0.0:
@@ -11253,21 +11593,21 @@ snapshots:
       - react
       - react-dom
 
-  '@fuel-ts/abi-coder@0.101.3':
+  '@fuel-ts/abi-coder@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/crypto': 0.101.3
+      '@fuel-ts/crypto': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/hasher': 0.101.3
+      '@fuel-ts/hasher': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       type-fest: 4.34.1
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/abi-typegen@0.101.3':
+  '@fuel-ts/abi-typegen@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/versions': 0.101.3
       commander: 13.1.0
       glob: 10.5.0
@@ -11278,17 +11618,17 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/account@0.101.3':
+  '@fuel-ts/account@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/address': 0.101.3
-      '@fuel-ts/crypto': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/address': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/crypto': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/hasher': 0.101.3
+      '@fuel-ts/hasher': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/merkle': 0.101.3
-      '@fuel-ts/transactions': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/merkle': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/transactions': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/versions': 0.101.3
       '@fuels/vm-asm': 0.60.2
       '@noble/curves': 1.8.1
@@ -11301,37 +11641,37 @@ snapshots:
       - encoding
       - vitest
 
-  '@fuel-ts/address@0.101.3':
+  '@fuel-ts/address@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/crypto': 0.101.3
+      '@fuel-ts/crypto': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@noble/hashes': 1.8.0
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/contract@0.101.3':
+  '@fuel-ts/contract@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/account': 0.101.3
-      '@fuel-ts/crypto': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/account': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/crypto': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/hasher': 0.101.3
+      '@fuel-ts/hasher': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/merkle': 0.101.3
-      '@fuel-ts/program': 0.101.3
-      '@fuel-ts/transactions': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/merkle': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/program': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/transactions': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuels/vm-asm': 0.60.2
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/crypto@0.101.3':
+  '@fuel-ts/crypto@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@noble/hashes': 1.8.0
     transitivePeerDependencies:
       - vitest
@@ -11340,10 +11680,10 @@ snapshots:
     dependencies:
       '@fuel-ts/versions': 0.101.3
 
-  '@fuel-ts/hasher@0.101.3':
+  '@fuel-ts/hasher@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/crypto': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/crypto': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@noble/hashes': 1.8.0
     transitivePeerDependencies:
       - vitest
@@ -11354,72 +11694,73 @@ snapshots:
       '@types/bn.js': 5.1.6
       bn.js: 5.2.3
 
-  '@fuel-ts/merkle@0.101.3':
+  '@fuel-ts/merkle@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/hasher': 0.101.3
+      '@fuel-ts/hasher': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/math': 0.101.3
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/program@0.101.3':
+  '@fuel-ts/program@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/account': 0.101.3
-      '@fuel-ts/address': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/account': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/address': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/transactions': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/transactions': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuels/vm-asm': 0.60.2
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/recipes@0.101.3':
+  '@fuel-ts/recipes@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/abi-typegen': 0.101.3
-      '@fuel-ts/account': 0.101.3
-      '@fuel-ts/address': 0.101.3
-      '@fuel-ts/contract': 0.101.3
-      '@fuel-ts/program': 0.101.3
-      '@fuel-ts/transactions': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/abi-typegen': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/account': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/address': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/contract': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/program': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/transactions': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/script@0.101.3':
+  '@fuel-ts/script@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/account': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/account': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/program': 0.101.3
-      '@fuel-ts/transactions': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/program': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/transactions': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/transactions@0.101.3':
+  '@fuel-ts/transactions@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/address': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/address': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/hasher': 0.101.3
+      '@fuel-ts/hasher': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/utils@0.101.3':
+  '@fuel-ts/utils@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
     dependencies:
       '@fuel-ts/errors': 0.101.3
       '@fuel-ts/math': 0.101.3
       '@fuel-ts/versions': 0.101.3
       fflate: 0.8.2
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)
 
   '@fuel-ts/versions@0.101.3':
     dependencies:
@@ -11630,6 +11971,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/sourcemap-codec@1.6.0': {}
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -12189,6 +12532,9 @@ snapshots:
       '@module-federation/sdk': 0.9.1
 
   '@msgpack/msgpack@3.1.2': {}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -14775,6 +15121,81 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
   '@rspack/binding-darwin-arm64@1.7.12':
     optional: true
 
@@ -16646,6 +17067,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/estree@1.0.9': {}
+
   '@types/express-serve-static-core@4.19.9':
     dependencies:
       '@types/node': 24.10.7
@@ -16959,6 +17382,50 @@ snapshots:
     optionalDependencies:
       next: 15.5.22(@types/node@24.10.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+
+  '@vitest/expect@3.0.9':
+    dependencies:
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.0.9(vite@6.4.3(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.0.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.0.9':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.0.9':
+    dependencies:
+      '@vitest/utils': 3.0.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.0.9':
+    dependencies:
+      '@vitest/pretty-format': 3.0.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.0.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@3.0.9':
+    dependencies:
+      '@vitest/pretty-format': 3.0.9
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@wagmi/connectors@5.7.7(@types/react@19.2.3)(@wagmi/core@2.16.4(@tanstack/query-core@5.90.16)(@types/react@19.2.3)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.11)))(bufferutil@4.1.0)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@4.1.11)':
     dependencies:
@@ -18425,6 +18892,8 @@ snapshots:
       object.assign: 4.1.7
       util: 0.12.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -18727,6 +19196,8 @@ snapshots:
 
   bytestreamjs@2.0.1: {}
 
+  cac@6.7.14: {}
+
   cache-content-type@1.0.1:
     dependencies:
       mime-types: 2.1.35
@@ -18786,6 +19257,14 @@ snapshots:
     dependencies:
       nofilter: 3.1.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -18799,6 +19278,8 @@ snapshots:
   chalk@5.6.2: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -19138,6 +19619,8 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  deep-eql@5.0.2: {}
+
   deep-equal@1.0.1: {}
 
   deep-is@0.1.4: {}
@@ -19408,6 +19891,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -19676,6 +20161,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -19872,6 +20361,8 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
+  expect-type@1.4.0: {}
+
   express@4.22.2:
     dependencies:
       accepts: 1.3.8
@@ -19917,6 +20408,8 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fake-indexeddb@6.2.5: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -19958,6 +20451,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   feaxios@0.0.23:
     dependencies:
@@ -20121,22 +20618,22 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fuels@0.101.3:
+  fuels@0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)):
     dependencies:
-      '@fuel-ts/abi-coder': 0.101.3
-      '@fuel-ts/abi-typegen': 0.101.3
-      '@fuel-ts/account': 0.101.3
-      '@fuel-ts/address': 0.101.3
-      '@fuel-ts/contract': 0.101.3
-      '@fuel-ts/crypto': 0.101.3
+      '@fuel-ts/abi-coder': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/abi-typegen': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/account': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/address': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/contract': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/crypto': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/errors': 0.101.3
-      '@fuel-ts/hasher': 0.101.3
+      '@fuel-ts/hasher': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/math': 0.101.3
-      '@fuel-ts/program': 0.101.3
-      '@fuel-ts/recipes': 0.101.3
-      '@fuel-ts/script': 0.101.3
-      '@fuel-ts/transactions': 0.101.3
-      '@fuel-ts/utils': 0.101.3
+      '@fuel-ts/program': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/recipes': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/script': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/transactions': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@fuel-ts/utils': 0.101.3(vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
       '@fuel-ts/versions': 0.101.3
       '@fuels/vm-asm': 0.60.2
       bundle-require: 5.1.0(esbuild@0.25.3)
@@ -21025,6 +21522,8 @@ snapshots:
 
   lossless-json@4.3.0: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-memorise@0.3.0:
@@ -21036,6 +21535,10 @@ snapshots:
       react: 19.2.3
 
   luxon@3.7.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   map-stream@0.1.0: {}
 
@@ -21582,6 +22085,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   pause-stream@0.0.11:
     dependencies:
       through: 2.3.8
@@ -21600,6 +22107,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.7: {}
 
   pify@2.3.0: {}
 
@@ -22276,6 +22785,38 @@ snapshots:
     dependencies:
       bn.js: 5.2.3
 
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
+
   rpc-websockets@9.3.2:
     dependencies:
       '@swc/helpers': 0.5.18
@@ -22572,6 +23113,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -22683,6 +23226,8 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   starknet@8.9.2:
     dependencies:
       '@noble/curves': 1.7.0
@@ -22777,6 +23322,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -22986,12 +23533,27 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -23506,6 +24068,81 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite-node@3.0.9(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.3(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.3(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.25.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.24
+      rollup: 4.63.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.10.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.29.2
+      yaml: 2.8.3
+
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3):
+    dependencies:
+      '@vitest/expect': 3.0.9
+      '@vitest/mocker': 3.0.9(vite@6.4.3(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.0.9
+      '@vitest/snapshot': 3.0.9
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)
+      vite-node: 3.0.9(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.29.2)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.10.7
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vm-browserify@1.1.2: {}
 
   wagmi@2.14.11(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.11(react@19.2.3))(@types/react@19.2.3)(bufferutil@4.1.0)(immer@11.1.15)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@4.1.11):
@@ -23755,6 +24392,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wif@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- persist compact swap route history in IndexedDB, scoped by API environment and capped at 500 records
- hydrate a reactive recency index and blend it into suggestion ranking after source wallet balances
- record created swaps, claimed deposit-prefetch swaps, and swaps fetched through History API flows
- preserve extended-route identities, exclude exchange sources, and add focused repository, hydration, extraction, and sorting tests

## Testing
- pnpm --filter @layerswap/widget test
- pnpm --filter @layerswap/wallet-core build
- pnpm --filter @layerswap/widget check:types
- pnpm --filter @layerswap/bridge check:types
- pnpm --filter @layerswap/widget build