### PR TITLE
Display token asset labels

### DIFF
--- a/apps/explorer/app/DataTable.tsx
+++ b/apps/explorer/app/DataTable.tsx
@@ -81,7 +81,7 @@ export default function DataTable() {
                                                                     </div>
                                                                     <div className="mx-2.5">
                                                                         <span className="text-primary-text">{formatAmount(input_transaction?.amount)}</span>
-                                                                        <span className="mx-1 text-primary-text">{sourceToken?.symbol}</span>
+                                                                        <span className="mx-1 text-primary-text">{sourceToken?.asset}</span>
                                                                     </div>
                                                                 </div>
                                                             </div>
@@ -117,7 +117,7 @@ export default function DataTable() {
                                                                     {output_transaction?.amount ?
                                                                         <div className="mx-2.5">
                                                                             <span className="text-primary-text">{formatAmount(output_transaction?.amount)}</span>
-                                                                            <span className="mx-1 text-primary-text">{destinationToken?.symbol}</span>
+                                                                            <span className="mx-1 text-primary-text">{destinationToken?.asset}</span>
                                                                         </div>
                                                                         :
                                                                         <span className="ml-2.5">-</span>

--- a/apps/explorer/components/RefundComp.tsx
+++ b/apps/explorer/components/RefundComp.tsx
@@ -21,7 +21,7 @@ export default function Refund({ refund }: { refund: Transaction }) {
                     <div className="flex items-center">
                         <span className="text-sm lg:text-base font-medium text-primary-text flex items-center">
                             <Image alt="Source token icon" src={asset?.logo || ''} width={20} height={20} decoding="async" data-nimg="responsive" className="rounded-md mr-2" />
-                            {formatAmount(refund?.amount)} {asset?.symbol}
+                            {formatAmount(refund?.amount)} {asset?.asset}
                         </span>
                     </div>
                 </div>

--- a/apps/explorer/components/SwapDetails/SwapDetailView.tsx
+++ b/apps/explorer/components/SwapDetails/SwapDetailView.tsx
@@ -16,6 +16,7 @@ interface SwapDetailViewProps {
         token?: {
             logo?: string;
             symbol?: string;
+            asset?: string;
             precision?: number;
         };
     };
@@ -69,7 +70,7 @@ export default function SwapDetailView({
                                         outputTransaction={outputTransaction}
                                         createdDate={created_date}
                                         totalFee={quote?.total_fee}
-                                        sourceTokenSymbol={source_token?.symbol}
+                                        sourceTokenSymbol={source_token?.asset}
                                         sourceTokenPrecision={source_token?.precision}
                                     />
                                 </div>
@@ -85,7 +86,7 @@ export default function SwapDetailView({
                                 transaction={inputTransaction}
                                 amount={inputTransaction.amount}
                                 tokenLogo={source_token?.logo}
-                                tokenSymbol={source_token?.symbol}
+                                tokenSymbol={source_token?.asset}
                                 networkLogo={source_network?.logo}
                                 networkName={source_exchange ? source_network?.display_name : undefined}
                                 exchangeLogo={source_exchange?.logo}
@@ -109,7 +110,7 @@ export default function SwapDetailView({
                                 refundedTransaction={refundedTransaction}
                                 amount={(outputTransaction || refundedTransaction)?.amount}
                                 tokenLogo={(refundToken || destination_token)?.logo}
-                                tokenSymbol={(refundToken || destination_token)?.symbol}
+                                tokenSymbol={(refundToken || destination_token)?.asset}
                                 networkLogo={(refundNetwork || destination_network)?.logo}
                                 networkName={destination_exchange ? destination_network?.display_name : undefined}
                                 exchangeLogo={destination_exchange?.logo}
@@ -125,7 +126,7 @@ export default function SwapDetailView({
                                         refuelTransaction={refuelTransaction}
                                         refuelAmount={refuel?.amount}
                                         refuelTokenLogo={refuel?.token?.logo}
-                                        refuelTokenSymbol={refuel?.token?.symbol}
+                                        refuelTokenSymbol={refuel?.token?.asset}
                                         refuelTokenPrecision={refuel?.token?.precision}
                                     />
                                 )}

--- a/apps/explorer/components/SwapDetails/SwapTableRow.tsx
+++ b/apps/explorer/components/SwapDetails/SwapTableRow.tsx
@@ -70,7 +70,7 @@ export default function SwapTableRow({
                                 </div>
                                 <div className="mx-2.5">
                                     <span className="text-primary-text">{formatAmount(inputTransaction.amount)}</span>
-                                    <span className="mx-1 text-primary-text">{source_token?.symbol}</span>
+                                    <span className="mx-1 text-primary-text">{source_token?.asset}</span>
                                 </div>
                             </div>
                         </div>
@@ -125,7 +125,7 @@ export default function SwapTableRow({
                                 {outputTransaction?.amount ? (
                                     <div className="mx-2.5">
                                         <span className="text-primary-text mx-0.5">{formatAmount(outputTransaction.amount)}</span>
-                                        <span className="text-primary-text">{destination_token?.symbol}</span>
+                                        <span className="text-primary-text">{destination_token?.asset}</span>
                                     </div>
                                 ) : (
                                     <span className="ml-2.5">-</span>

--- a/apps/explorer/components/SwapDetails/types.ts
+++ b/apps/explorer/components/SwapDetails/types.ts
@@ -20,6 +20,7 @@ export interface NetworkAssetInfo {
     token?: {
         logo?: string;
         symbol?: string;
+        asset?: string;
         precision?: number;
     };
     exchange?: {
@@ -27,4 +28,3 @@ export interface NetworkAssetInfo {
         display_name?: string;
     };
 }
-

--- a/apps/explorer/models/Swap.ts
+++ b/apps/explorer/models/Swap.ts
@@ -1,6 +1,7 @@
 
 export type Token = {
     symbol: string;
+    asset: string;
     logo: string;
     contract: string;
     decimals: number;

--- a/apps/widget-playground/src/components/buttons/DepositDestinations/DepositDestinationsButton.tsx
+++ b/apps/widget-playground/src/components/buttons/DepositDestinations/DepositDestinationsButton.tsx
@@ -14,10 +14,10 @@ const renderNetworkOption = (net: { name: string; display_name?: string; logo?: 
     </div>
 );
 
-const renderTokenOption = (tok: { symbol: string; logo?: string }) => (
+const renderTokenOption = (tok: { asset: string; logo?: string }) => (
     <div className="flex items-center gap-2">
-        {tok.logo && <img src={tok.logo} alt={tok.symbol} className="rounded-sm w-5 h-5" />}
-        <span>{tok.symbol}</span>
+        {tok.logo && <img src={tok.logo} alt={tok.asset} className="rounded-sm w-5 h-5" />}
+        <span>{tok.asset}</span>
     </div>
 );
 

--- a/apps/widget-playground/src/components/buttons/InitialSettings/SettingsCard.tsx
+++ b/apps/widget-playground/src/components/buttons/InitialSettings/SettingsCard.tsx
@@ -24,7 +24,7 @@ const resolveSelectItem = (item: any) => {
     }
 
     const value = item.value ?? item.name ?? item.symbol;
-    const label = item.label ?? item.display_name ?? item.symbol;
+    const label = item.label ?? item.display_name ?? item.asset ?? item.symbol;
     const logo = item.logo;
     const icon = item.icon;
 

--- a/packages/wallets/adapters/evm/src/additionalProviders/hyperliquid/createHyperliquidTransferProvider.ts
+++ b/packages/wallets/adapters/evm/src/additionalProviders/hyperliquid/createHyperliquidTransferProvider.ts
@@ -99,7 +99,7 @@ export function createHyperliquidTransfer(): TransferProvider {
             const split = await client.getWithdrawableSplit(sourceAddress, hlConfig.nodeUrl, sourceToken.symbol)
             const plan = planWithdrawal(split, required, decimals)
             if (plan.insufficient) {
-                throw fail('Insufficient balance', `Your available Hyperliquid balance (${split.combined} ${sourceToken.symbol}) is below ${amount} ${sourceToken.symbol}.`)
+                throw fail('Insufficient balance', `Your available Hyperliquid balance (${split.combined} ${sourceToken.asset}) is below ${amount} ${sourceToken.asset}.`)
             }
 
             let sourceDex = plan.sourceDex
@@ -112,7 +112,7 @@ export function createHyperliquidTransfer(): TransferProvider {
                 // signature) and let it paint before the wallet prompt opens.
                 onProgress?.({
                     title: 'Approve moving your balance',
-                    description: `Moving ${plan.transfer.amount} ${sourceToken.symbol} from your Hyperliquid ${fromLabel} balance to ${toLabel} so this withdrawal can be funded. The funds stay on Hyperliquid and there's no fee — you'll approve the withdrawal itself next.`,
+                    description: `Moving ${plan.transfer.amount} ${sourceToken.asset} from your Hyperliquid ${fromLabel} balance to ${toLabel} so this withdrawal can be funded. The funds stay on Hyperliquid and there's no fee — you'll approve the withdrawal itself next.`,
                 })
                 await sleep(50)
                 transferNonce = Date.now()

--- a/packages/wallets/adapters/evm/src/additionalProviders/polymarket/createPolymarketTransferProvider.ts
+++ b/packages/wallets/adapters/evm/src/additionalProviders/polymarket/createPolymarketTransferProvider.ts
@@ -139,7 +139,7 @@ export function createPolymarketTransferProvider(
             }
             if (!funder) {
                 const largest = executable[0]
-                throw fail('Insufficient balance', `Your available Polymarket balance (${largest.amount} ${sourceToken.symbol}) is below the withdrawal amount.`)
+                throw fail('Insufficient balance', `Your available Polymarket balance (${largest.amount} ${sourceToken.asset}) is below the withdrawal amount.`)
             }
 
             // Assemble the batch (unwrap if holding pUSD, then approve + deposit). The calls are

--- a/packages/wallets/adapters/evm/src/additionalProviders/polymarket/polymarketExtendedRouteProvider.ts
+++ b/packages/wallets/adapters/evm/src/additionalProviders/polymarket/polymarketExtendedRouteProvider.ts
@@ -56,6 +56,7 @@ export const polymarketProvider: ExtendedRouteProvider = {
         const token: Token = {
             ...baseToken,
             symbol: POLYMARKET_DISPLAY_SYMBOL,
+            asset: POLYMARKET_DISPLAY_SYMBOL,
             display_asset: POLYMARKET_DISPLAY_SYMBOL,
             contract: POLYMARKET_PUSD_ADDRESS,
         }

--- a/packages/wallets/adapters/svm/src/svmBalanceProvider.ts
+++ b/packages/wallets/adapters/svm/src/svmBalanceProvider.ts
@@ -65,7 +65,7 @@ export class SolanaBalanceProvider extends BalanceProvider {
                 }
 
                 return this.resolveTokenBalanceFetchError(
-                    new Error(`Invalid balance returned for ${token.symbol}`),
+                    new Error(`Invalid balance returned for ${token.asset}`),
                     token,
                     network,
                     !token.contract,

--- a/packages/widget/core/src/Models/Route.ts
+++ b/packages/widget/core/src/Models/Route.ts
@@ -19,6 +19,7 @@ export type TitleElement = {
 export type GroupedTokenElement = {
     type: 'grouped_token';
     symbol: string;
+    asset: string;
     items: NetworkTokenElement[];
 }
 export type TokenSceletonElement = {

--- a/packages/widget/core/src/components/Input/Address/AddressPicker/AddressWithIcon.tsx
+++ b/packages/widget/core/src/components/Input/Address/AddressPicker/AddressWithIcon.tsx
@@ -21,7 +21,7 @@ type Props = {
     addressItem: AddressItem;
     partner?: Partner;
     network?: Network;
-    balance?: { amount: number, symbol: string, isLoading: boolean } | undefined;
+    balance?: { amount: number, asset: string, isLoading: boolean } | undefined;
     onDisconnect?: ExtendedAddressProps['onDisconnect']
     onRemove?: ExtendedAddressProps['onRemove']
 }
@@ -132,7 +132,7 @@ const AddressWithIcon: FC<Props> = ({ addressItem, partner, network, balance, on
                                         <div className='h-[14px] w-20 inline-flex bg-gray-500 rounded-xs animate-pulse' />
                                         :
                                         <>
-                                            <span>{balance.amount.toLocaleString()}</span> <span>{balance.symbol}</span>
+                                            <span>{balance.amount.toLocaleString()}</span> <span>{balance.asset}</span>
                                         </>
                                 }
                             </div>

--- a/packages/widget/core/src/components/Input/Amount/ExchangeReceiveAmount.tsx
+++ b/packages/widget/core/src/components/Input/Amount/ExchangeReceiveAmount.tsx
@@ -22,7 +22,7 @@ export const ExchangeReceiveAmount: FC<ReceiveAmountProps> = ({ destination_toke
                     { "text-secondary-text": !receive_amount }
                 )}>
                     <NumFlowWithFallback value={receive_amount || 0} trend={0} format={{ maximumFractionDigits: fee?.quote.destination_token?.decimals || 2 }} />
-                    <span className="ml-1">{destination_token?.symbol}</span>
+                    <span className="ml-1">{destination_token?.asset}</span>
                 </div>
             </div>
             <div className="flex items-baseline space-x-2 mt-1.5">

--- a/packages/widget/core/src/components/Input/Amount/ReceiveAmount.tsx
+++ b/packages/widget/core/src/components/Input/Amount/ReceiveAmount.tsx
@@ -51,7 +51,7 @@ export const ReceiveAmount: FC<ReceiveAmountProps> = ({ destination_token, fee, 
             ctx.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
 
             const intPart = receive_amount ? Math.floor(receive_amount).toString() : '0';
-            const suffix = ` ${destination_token?.symbol || ''}`;
+            const suffix = ` ${destination_token?.asset || ''}`;
             const fixedWidth = ctx.measureText(intPart + '.').width + ctx.measureText(suffix).width;
 
             if (fixedWidth >= availableWidth) {
@@ -70,7 +70,7 @@ export const ReceiveAmount: FC<ReceiveAmountProps> = ({ destination_token, fee, 
         observer.observe(container);
 
         return () => observer.disconnect();
-    }, [isUsdMode, receive_amount, destination_token?.symbol, tokenDecimals]);
+    }, [isUsdMode, receive_amount, destination_token?.asset, tokenDecimals]);
 
     useEffect(() => {
         if (!isUsdMode) setMaxDecimals(Math.min(tokenDecimals, 7));
@@ -97,7 +97,7 @@ export const ReceiveAmount: FC<ReceiveAmountProps> = ({ destination_token, fee, 
                 <span ref={numberSpanRef} className="text-xs sm:text-base leading-5 inline-flex items-center font-medium text-secondary-text h-5 min-w-0">
                     {isUsdMode ? <>
                         <NumFlowWithFallback className="p-0 align-middle shrink-0" value={receive_amount || 0} trend={0} format={{ maximumFractionDigits: maxDecimals }} />
-                        <span className="truncate ml-1">{destination_token?.symbol}</span>
+                        <span className="truncate ml-1">{destination_token?.asset}</span>
                     </> : (
                         <NumFlowWithFallback className="p-0 align-middle" value={Number(receiveAmountInUsd) || 0} prefix="$" format={{ maximumFractionDigits: receiveAmountInUsd ? 2 : 0 }} trend={0} />
                     )}

--- a/packages/widget/core/src/components/Input/Amount/index.tsx
+++ b/packages/widget/core/src/components/Input/Amount/index.tsx
@@ -144,7 +144,7 @@ const AmountField = forwardRef(function AmountField({ actionValue, actionValueUs
                             {`${previewToken ?? formattedTokenAmount}`}
                         </span>
                         <span className="shrink-0">
-                            {` ${fromCurrency?.symbol || ''}`}
+                            {` ${fromCurrency?.asset || ''}`}
                         </span>
                     </span>
                 </div>
@@ -201,4 +201,3 @@ function getFontFromElement(el: HTMLElement | null): string {
     const style = window.getComputedStyle(el);
     return `${style.fontSize} ${style.fontFamily}`;
 }
-

--- a/packages/widget/core/src/components/Input/RoutePicker/RouteSearch.tsx
+++ b/packages/widget/core/src/components/Input/RoutePicker/RouteSearch.tsx
@@ -21,7 +21,7 @@ const RouteSearch: FC<RouteSearchProps> = ({ searchQuery, setSearchQuery, should
             .filter((route) => route.tokens?.length)
             .map((route) => {
                 const token = route.tokens[Math.floor(Math.random() * route.tokens.length)];
-                return `Try "${token.symbol} ${route.display_name || route.name}"`;
+                return `Try "${token.asset} ${route.display_name || route.name}"`;
             });
         return ["Search by token and network", ...routeTexts];
     }, [routes])

--- a/packages/widget/core/src/components/Input/RoutePicker/Routes.tsx
+++ b/packages/widget/core/src/components/Input/RoutePicker/Routes.tsx
@@ -29,7 +29,7 @@ export const CurrencySelectItemDisplay = memo((props: TokenItemProps) => {
     return <SelectItem className="group">
         <SelectItem.Logo
             imgSrc={item.logo}
-            altText={`${item.symbol} logo`}
+            altText={`${item.asset} logo`}
             className="rounded-full"
         />
         <NetworkTokenTitle item={item} route={route} direction={direction} type={type} hideBalances={hideBalances} />
@@ -131,7 +131,7 @@ export const NetworkRouteSelectItemDisplay = (props: NetworkRouteItemProps) => {
                                         <ImageWithFallback
                                             key={`${t.symbol}-${index}`}
                                             src={t.logo}
-                                            alt={`${t.symbol} logo`}
+                                            alt={`${t.asset} logo`}
                                             height="16"
                                             width="16"
                                             loading="eager"
@@ -162,7 +162,7 @@ export const NetworkRouteSelectItemDisplay = (props: NetworkRouteItemProps) => {
 type SelectedCurrencyDisplayProps = {
     value: {
         logo: string
-        symbol: string
+        asset: string
     } | undefined;
     placeholder: string;
 }
@@ -230,13 +230,13 @@ export const GroupedTokenHeader = ({
         <SelectItem className="accordion-item-focused bg-secondary-500 group rounded-xl hover:bg-secondary-400 group/item relative pr-7 py-2">
             <SelectItem.Logo
                 imgSrc={mainToken.logo}
-                altText={`${mainToken.symbol} logo`}
+                altText={`${mainToken.asset} logo`}
                 className="rounded-full"
             />
             <SelectItem.Title>
                 <>
                     <span className="flex items-center gap-1.5 min-w-0">
-                        <span className="truncate">{mainToken.symbol}</span>
+                        <span className="truncate">{mainToken.asset}</span>
                     </span>
                     {hasLoadedBalances ? (
                         <div className={`${showNetworkIcons ? "flex flex-col space-y-0.5" : ""} ${hideTokenImages ? "invisible" : "visible"}`}>
@@ -299,7 +299,7 @@ export const SelectedCurrencyDisplay = (props: SelectedCurrencyDisplayProps) => 
         }
         {value ?
             <span className="ml-3 flex font-medium flex-auto space-x-1 text-primary-text items-center">
-                {value.symbol}
+                {value.asset}
             </span>
             :
             <span className="block font-medium text-primary-text-tertiary flex-auto items-center">
@@ -347,7 +347,7 @@ export const SelectedRouteDisplay = ({ route, token, placeholder }: SelectedRout
                         </div>
                     </div>
                     <div className="ml-2 flex flex-col grow text-primary-text overflow-hidden min-w-0 max-w-3/4 group-[.exchange-picker]:max-w-full xs:max-w-[60px]"                    >
-                        <p className="text-base leading-5 font-medium">{token.symbol}</p>
+                        <p className="text-base leading-5 font-medium">{token.asset}</p>
                         <p className="text-secondary-text grow text-sm font-normal leading-4 truncate whitespace-nowrap">
                             {route.display_name}
                         </p>

--- a/packages/widget/core/src/components/Input/RoutePicker/TokenTitleDetails.tsx
+++ b/packages/widget/core/src/components/Input/RoutePicker/TokenTitleDetails.tsx
@@ -28,7 +28,7 @@ export const TokenInfoIcon = ({ item, route, className }: { item: NetworkRouteTo
                     showDetails
                     address={item.contract}
                     logo={item.logo}
-                    title={item.symbol}
+                    title={item.asset}
                     description={item.display_asset}
                     onPopoverOpenChange={setIsPopoverOpen}
                     onTooltipOpenChange={setIsTooltipOpen}
@@ -55,7 +55,7 @@ export const TokenTitleWithBalance = ({ item, route, tokenbalance, usdAmount }: 
         <div className="flex items-center gap-2 justify-between w-full min-w-0">
             <div className="flex items-center gap-2 py-px min-w-0 flex-1 overflow-hidden">
                 <p className="shrink-0">
-                    {item.symbol}
+                    {item.asset}
                 </p>
                 <TokenInfoIcon
                     item={item}
@@ -78,7 +78,7 @@ const TokenInfoTrigger = ({ item, isPopoverOpen, isTooltipOpen }: TokenInfoTrigg
     return (
         <span className="flex items-center gap-1 text-secondary-text cursor-pointer hover:text-primary-text data-[popover-open=true] data-[tooltip-open=true] text-xs pr-2" data-popover-open={isPopoverOpen} data-tooltip-open={isTooltipOpen}>
             <p className="truncate min-w-0">
-                <span>•</span> <span>{item.display_asset || item.symbol}</span>
+                <span>•</span> <span>{item.display_asset || item.asset}</span>
             </p>
             <Info className="h-3 w-3 shrink-0" />
         </span>
@@ -128,7 +128,7 @@ const NativeTokenTitle = ({ item, route, onTooltipOpenChange, onPopoverOpenChang
                         <div className="flex items-center gap-3">
                             <ImageWithFallback
                                 src={item.logo}
-                                alt={item.symbol}
+                                alt={item.asset}
                                 height="40"
                                 width="40"
                                 loading="eager"
@@ -136,7 +136,7 @@ const NativeTokenTitle = ({ item, route, onTooltipOpenChange, onPopoverOpenChang
                                 className="rounded-full object-contain shrink-0 h-10 w-10"
                             />
                             <div className="flex-1 font-medium">
-                                <h3 className="text-base leading-5 text-primary-text">{item.symbol}</h3>
+                                <h3 className="text-base leading-5 text-primary-text">{item.asset}</h3>
                                 <p className="text-sm leading-[18px] text-secondary-text">{item.display_asset}</p>
                             </div>
                         </div>
@@ -144,7 +144,7 @@ const NativeTokenTitle = ({ item, route, onTooltipOpenChange, onPopoverOpenChang
                     </div>
 
                     <p className="text-secondary-text text-sm leading-5 break-all text-left font-mono">
-                        {route.display_name} <span>{item.symbol}</span>{' native coin'}
+                        {route.display_name} <span>{item.asset}</span>{' native coin'}
                     </p>
                 </PopoverContent>
             </Popover>

--- a/packages/widget/core/src/components/Pages/Campaigns/Details/Leaderboard.tsx
+++ b/packages/widget/core/src/components/Pages/Campaigns/Details/Leaderboard.tsx
@@ -132,7 +132,7 @@ const LeaderbordComponent: FC<{
                                                     <span className="text-primary">You</span>
                                                 </a>}
                                             </div>
-                                            <p className="mt-1 text-sm font-medium text-secondary-text leading-3">{truncateDecimals(rewards.user_reward.total_amount, token?.precision)} {token?.symbol}</p>
+                                            <p className="mt-1 text-sm font-medium text-secondary-text leading-3">{truncateDecimals(rewards.user_reward.total_amount, token?.precision)} {token?.asset}</p>
                                         </div>
                                     </div >
                                 </div >
@@ -169,7 +169,7 @@ const LeaderboardItem: FC<{
                             {user.position === rewards?.user_reward?.position ? <span className="text-primary">You</span> : displayName}
                         </a>}
                     </div>
-                    <p className="mt-1 text-sm font-medium text-secondary-text leading-3">{truncateDecimals(user.amount, token?.precision)} {token?.symbol}</p>
+                    <p className="mt-1 text-sm font-medium text-secondary-text leading-3">{truncateDecimals(user.amount, token?.precision)} {token?.asset}</p>
                 </div>
             </div >
         </div >
@@ -189,7 +189,7 @@ const LeaderboardItem: FC<{
                                 className="rounded-full object-contain" />
                         </div>
                         <p>
-                            <span>{leaderboardRewards[user.position - 1]} {token?.symbol}</span>
+                            <span>{leaderboardRewards[user.position - 1]} {token?.asset}</span>
                         </p>
                     </div>
                 } />

--- a/packages/widget/core/src/components/Pages/Campaigns/Details/Rewards.tsx
+++ b/packages/widget/core/src/components/Pages/Campaigns/Details/Rewards.tsx
@@ -68,7 +68,7 @@ const Rewards: FC<Props> = ({ campaign }) => {
             </div>
             <div className="bg-secondary-500 divide-y divide-secondary-500 rounded-lg shadow-lg border border-secondary-500 hover:border-secondary-400 transition duration-200">
                 {!campaignIsEnded &&
-                    <BackgroundField header={<span className="flex justify-between"><span className="flex items-center"><span>Pending Earnings&nbsp;</span><ClickTooltip text={`${campaign.token.symbol} tokens that will be airdropped periodically.`} /> </span><span>Next Airdrop</span></span>} withoutBorder>
+                    <BackgroundField header={<span className="flex justify-between"><span className="flex items-center"><span>Pending Earnings&nbsp;</span><ClickTooltip text={`${campaign.token.asset} tokens that will be airdropped periodically.`} /> </span><span>Next Airdrop</span></span>} withoutBorder>
                         <div className="flex justify-between w-full text-2xl">
                             <div className="flex items-center space-x-1">
                                 <div className="h-5 w-5 relative">
@@ -81,7 +81,7 @@ const Rewards: FC<Props> = ({ campaign }) => {
                                         className="rounded-full object-contain" />
                                 </div>
                                 <p>
-                                    {rewards?.user_reward.total_pending_amount} <span className="text-base sm:text-2xl">{campaign.token.symbol}</span>
+                                    {rewards?.user_reward.total_pending_amount} <span className="text-base sm:text-2xl">{campaign.token.asset}</span>
                                 </p>
                             </div>
                             <div className="flex items-center space-x-1">
@@ -93,7 +93,7 @@ const Rewards: FC<Props> = ({ campaign }) => {
                         </div>
                     </BackgroundField>
                 }
-                <BackgroundField header={<span className="flex justify-between"><span className="flex items-center"><span>Total Earnings&nbsp;</span><ClickTooltip text={`${campaign.token.symbol} tokens that you've earned so far (including Pending Earnings).`} /></span><span>Current Value</span></span>} withoutBorder>
+                <BackgroundField header={<span className="flex justify-between"><span className="flex items-center"><span>Total Earnings&nbsp;</span><ClickTooltip text={`${campaign.token.asset} tokens that you've earned so far (including Pending Earnings).`} /></span><span>Current Value</span></span>} withoutBorder>
                     <div className="flex justify-between w-full text-slate-300 text-2xl">
                         <div className="flex items-center space-x-1">
                             <div className="h-5 w-5 relative">
@@ -106,7 +106,7 @@ const Rewards: FC<Props> = ({ campaign }) => {
                                     className="rounded-full object-contain" />
                             </div>
                             <p>
-                                {rewards?.user_reward.total_amount} <span className="text-base sm:text-2xl">{campaign.token.symbol}</span>
+                                {rewards?.user_reward.total_amount} <span className="text-base sm:text-2xl">{campaign.token.asset}</span>
                             </p>
                         </div>
                         <p>
@@ -176,7 +176,7 @@ const ProgressComponent: FC<{ campaign: Campaign, rewardsData: Reward | undefine
                 <div className="flex flex-col w-full gap-2">
                     <Progress value={weeklyEarned === Infinity ? 0 : weeklyEarned} />
                     <div className="flex justify-between w-full font-semibold text-sm ">
-                        <div className="text-primary"><span className="text-primary-text">{weeklyEarned.toFixed(0)}</span> <span>/</span> {campaign.max_payout_amount} {campaign.token.symbol}</div>
+                        <div className="text-primary"><span className="text-primary-text">{weeklyEarned.toFixed(0)}</span> <span>/</span> {campaign.max_payout_amount} {campaign.token.asset}</div>
                         <div>
                             <span>Refreshes every </span> <span className="font-semibold">{campaign.reward_limit_period}</span> <span> days</span>
                         </div>
@@ -194,15 +194,15 @@ const ProgressComponent: FC<{ campaign: Campaign, rewardsData: Reward | undefine
             <BackgroundField header={
                 <>
                     <div className="flex items-center">
-                        <span>{campaign.token.symbol} pool</span>
-                        <ClickTooltip text={`The amount of ${campaign.token.symbol} to be distributed during this round of the campaign.`} />
+                        <span>{campaign.token.asset} pool</span>
+                        <ClickTooltip text={`The amount of ${campaign.token.asset} to be distributed during this round of the campaign.`} />
                     </div>
                 </>
             } withoutBorder>
                 <div className="flex flex-col w-full gap-2">
                     <Progress value={DistributedAmount === Infinity ? 0 : DistributedAmount} />
                     <div className="flex justify-between w-full font-semibold text-sm ">
-                        <div className="text-primary"><span className="text-primary-text">{campaign?.distributed_amount.toFixed(0)}</span> <span>/</span> {totalBudget} {campaign.token.symbol}</div>
+                        <div className="text-primary"><span className="text-primary-text">{campaign?.distributed_amount.toFixed(0)}</span> <span>/</span> {totalBudget} {campaign.token.asset}</div>
                     </div>
                 </div>
             </BackgroundField>

--- a/packages/widget/core/src/components/Pages/Campaigns/Details/index.tsx
+++ b/packages/widget/core/src/components/Pages/Campaigns/Details/index.tsx
@@ -90,7 +90,7 @@ const BriefInformation: FC<BriefInformationProps> = ({ campaign }) =>
             :
             <>
                 <span>You can earn $</span>
-                <span>{campaign?.token.symbol}</span>
+                <span>{campaign?.token.asset}</span>
                 <span>&nbsp;tokens by transferring assets to&nbsp;</span>
                 <span>{campaign.network.display_name}.</span>
                 <span> For each transaction, you&#39;ll receive&nbsp;</span>

--- a/packages/widget/core/src/components/Pages/Deposit/DestinationTokenPicker.tsx
+++ b/packages/widget/core/src/components/Pages/Deposit/DestinationTokenPicker.tsx
@@ -115,13 +115,13 @@ const DestinationTokenPicker: FC = () => {
                                     <span className="flex items-center gap-3 min-w-0">
                                         <TokenChainBadge
                                             tokenLogo={r.token.logo}
-                                            tokenSymbol={r.token.symbol}
+                                            tokenSymbol={r.token.asset}
                                             networkLogo={r.network.logo}
                                             networkName={r.network.display_name}
                                             size={32}
                                         />
                                         <span className="flex flex-col min-w-0 text-left leading-tight">
-                                            <span className="text-primary-text text-base font-semibold truncate">{r.token.symbol}</span>
+                                            <span className="text-primary-text text-base font-semibold truncate">{r.token.asset}</span>
                                             <span className="text-secondary-text text-sm truncate">{r.network.display_name}</span>
                                         </span>
                                     </span>

--- a/packages/widget/core/src/components/Pages/Deposit/Options/MethodPicker.tsx
+++ b/packages/widget/core/src/components/Pages/Deposit/Options/MethodPicker.tsx
@@ -180,7 +180,7 @@ const MethodPicker: FC = () => {
                     if (!(option.present && canShow(id))) return null;
                     const name = option.network?.display_name ?? "";
                     const balanceLabel = (option.compatibleWalletBalance != null && option.compatibleWalletBalance > 0) && option.token
-                        ? `Balance: ${truncateDecimals(option.compatibleWalletBalance, option.token.precision)} ${option.token.symbol}`
+                        ? `Balance: ${truncateDecimals(option.compatibleWalletBalance, option.token.precision)} ${option.token.asset}`
                         : undefined;
                     return (
                         <MethodCard

--- a/packages/widget/core/src/components/Pages/Deposit/Wallet/AmountStep.tsx
+++ b/packages/widget/core/src/components/Pages/Deposit/Wallet/AmountStep.tsx
@@ -91,7 +91,7 @@ const AmountStep: FC = () => {
                     <QuoteSummary
                         receiveAmount={receiveAmount != null ? Number(receiveAmount) : undefined}
                         receiveAmountInUsd={receiveAmountInUsd}
-                        tokenSymbol={toAsset?.symbol}
+                        tokenSymbol={toAsset?.asset}
                         token={toAsset}
                         isLoading={isQuoteLoading}
                     />

--- a/packages/widget/core/src/components/Pages/Deposit/_shared/PickerTriggerContent.tsx
+++ b/packages/widget/core/src/components/Pages/Deposit/_shared/PickerTriggerContent.tsx
@@ -8,7 +8,7 @@ type PickerTriggerContentProps = {
     label: string;
     /** When provided, the trigger shows the token + network. When omitted,
      * the placeholder is shown instead. */
-    token?: { logo?: string; symbol: string };
+    token?: { logo?: string; asset: string };
     network?: { logo?: string; display_name: string };
     placeholder?: string;
     showChevron?: boolean;
@@ -34,7 +34,7 @@ const PickerTriggerContent: FC<PickerTriggerContentProps> = ({
             {hasSelection ? (
                 <TokenChainBadge
                     tokenLogo={token!.logo}
-                    tokenSymbol={token!.symbol}
+                    tokenSymbol={token!.asset}
                     networkLogo={network!.logo}
                     networkName={network!.display_name}
                     size={32}
@@ -48,7 +48,7 @@ const PickerTriggerContent: FC<PickerTriggerContentProps> = ({
                 </span>
                 {hasSelection ? (
                     <span className="leading-tight truncate">
-                        <span className="text-base font-semibold text-primary-text">{token!.symbol}</span>
+                        <span className="text-base font-semibold text-primary-text">{token!.asset}</span>
                         <span className="ml-1 text-sm font-normal text-secondary-text">on {network!.display_name}</span>
                     </span>
                 ) : (

--- a/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/DepositQuoteDetails.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/DepositQuoteDetails.tsx
@@ -84,13 +84,13 @@ const DepositQuoteDetails: FC<DepositQuoteDetailsProps> = ({
     const minDepositDisplay = useMemo(() => {
         const min = sortedTiers[0]?.min_amount;
         if (!min || !sourceToken) return null;
-        return `${formatTokenAmount(min)} ${sourceToken.symbol}`;
+        return `${formatTokenAmount(min)} ${sourceToken.asset}`;
     }, [sortedTiers, sourceToken]);
 
     const maxDepositDisplay = useMemo(() => {
         const max = sortedTiers[sortedTiers.length - 1]?.max_amount;
         if (!max || !Number.isFinite(max) || !sourceToken) return null;
-        return `${formatTokenAmount(max)} ${sourceToken.symbol}`;
+        return `${formatTokenAmount(max)} ${sourceToken.asset}`;
     }, [sortedTiers, sourceToken]);
 
     const feeDisplay = sortedTiers[0]

--- a/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/FeeCalculator.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/FeeCalculator.tsx
@@ -33,13 +33,13 @@ const RouteChip = memo(({ network, token }: { network: Network | undefined; toke
         <span className="flex items-center gap-2 shrink-0 min-w-0">
             <TokenChainBadge
                 tokenLogo={token.logo}
-                tokenSymbol={token.symbol}
+                tokenSymbol={token.asset}
                 networkLogo={network.logo}
                 networkName={network.display_name}
                 size={28}
             />
             <span className="flex flex-col min-w-0 max-w-[110px]">
-                <span className="text-sm font-semibold text-primary-text leading-tight">{token.symbol}</span>
+                <span className="text-sm font-semibold text-primary-text leading-tight">{token.asset}</span>
                 <span className="text-xs font-normal text-secondary-text leading-tight truncate">{network.display_name}</span>
             </span>
         </span>

--- a/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/helpers.ts
+++ b/packages/widget/core/src/components/Pages/Swap/Form/DepositAddressForm/helpers.ts
@@ -11,10 +11,10 @@ export function formatFee(percentageFee: number, fixedFeeUsd: number): string {
     return parts.join(' + ') || 'Free';
 }
 
-export function formatTierRange(tier: DetailedQuoteModel, isFirst: boolean, isLast: boolean, symbol: string): string {
+export function formatTierRange(tier: DetailedQuoteModel, isFirst: boolean, isLast: boolean, asset: string): string {
     const min = formatTokenAmount(tier.min_amount);
     const max = formatTokenAmount(tier.max_amount);
-    if (isFirst) return `Up to ${max} ${symbol}`;
-    if (isLast) return `Over ${min} ${symbol}`;
-    return `${min} – ${max} ${symbol}`;
+    if (isFirst) return `Up to ${max} ${asset}`;
+    if (isLast) return `Over ${min} ${asset}`;
+    return `${min} – ${max} ${asset}`;
 }

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/Rate.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/Rate.tsx
@@ -25,15 +25,15 @@ export const RateElement = ({
         >
             {!flipped ? (
                 <>
-                    <p><span>1</span> <span>{fromAsset?.symbol}</span></p>
+                    <p><span>1</span> <span>{fromAsset?.asset}</span></p>
                     <ArrowRight className="w-3 h-3 mx-1" />
-                    <span>{rateTruncated} {toAsset?.symbol}</span>
+                    <span>{rateTruncated} {toAsset?.asset}</span>
                 </>
             ) : (
                 <>
-                    <p><span>1</span> <span>{toAsset?.symbol}</span></p>
+                    <p><span>1</span> <span>{toAsset?.asset}</span></p>
                     <ArrowRight className="w-3 h-3 mx-1" />
-                    <span>{flippedRateTruncated} {fromAsset?.symbol}</span>
+                    <span>{flippedRateTruncated} {fromAsset?.asset}</span>
                 </>
             )}
         </div>

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/ReceiveAmounts.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/ReceiveAmounts.tsx
@@ -33,7 +33,7 @@ export const ReceiveAmounts: FC<WillReceiveProps> = ({ source_token, destination
                                     <>{parsedReceiveAmount}</>
                                     &nbsp;
                                     <span>
-                                        {destination_token?.symbol}
+                                        {destination_token?.asset}
                                     </span>
                                     {
                                         receiveAmountInUsd !== undefined && Number(receiveAmountInUsd) > 0 &&

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/Refuel.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/Refuel.tsx
@@ -76,7 +76,7 @@ const RefuelToggle: FC<RefuelProps> = ({ onButtonClick, quote }) => {
                     {
                         refuel && !quote &&
                         <p className="text-xs">
-                            <span>You&apos;ll get</span> <span>{toCurrency.refuel?.token.symbol}</span> <span>for gas fees</span>
+                            <span>You&apos;ll get</span> <span>{toCurrency.refuel?.token.asset}</span> <span>for gas fees</span>
                         </p>
                     }
                 </button>

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/RefuelModal.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/RefuelModal.tsx
@@ -36,11 +36,11 @@ const RefuelModal: FC<RefuelModalProps> = ({ openModal, setOpenModal, fee }) => 
                         {
                             fee && refuel ?
                                 <>
-                                    <span><span>We&apos;ll convert</span> <span>${fee?.refuel?.amount_in_usd}</span> <span>of your transfer into</span> <span>{nativeAsset?.symbol}</span> <span>so you can start using your funds on the destination chain immediately.</span></span>
+                                    <span><span>We&apos;ll convert</span> <span>${fee?.refuel?.amount_in_usd}</span> <span>of your transfer into</span> <span>{nativeAsset?.asset}</span> <span>so you can start using your funds on the destination chain immediately.</span></span>
                                 </>
                                 :
                                 <>
-                                    <span><span>We&apos;ll convert a small portion of your transfer into</span> <span>{nativeAsset?.symbol}</span> <span>so you can start using your funds on the destination chain immediately.</span></span>
+                                    <span><span>We&apos;ll convert a small portion of your transfer into</span> <span>{nativeAsset?.asset}</span> <span>so you can start using your funds on the destination chain immediately.</span></span>
                                 </>
                         }
                     </p>
@@ -55,7 +55,7 @@ const RefuelModal: FC<RefuelModalProps> = ({ openModal, setOpenModal, fee }) => 
                                                     <span>Current balance</span>
                                                 </div>
                                                 <p className='text-end'>
-                                                    <span>{truncateDecimals(destNativeTokenBalance?.amount!, nativeAsset?.precision)} {nativeAsset?.symbol}</span>
+                                                    <span>{truncateDecimals(destNativeTokenBalance?.amount!, nativeAsset?.precision)} {nativeAsset?.asset}</span>
                                                 </p>
                                             </div>
                                         </div>
@@ -70,7 +70,7 @@ const RefuelModal: FC<RefuelModalProps> = ({ openModal, setOpenModal, fee }) => 
                                                     You will receive
                                                 </div>
                                                 <p>
-                                                    <span>{truncateDecimals(toCurrency.refuel?.amount, nativeAsset.precision)} {nativeAsset?.symbol}</span>
+                                                    <span>{truncateDecimals(toCurrency.refuel?.amount, nativeAsset.precision)} {nativeAsset?.asset}</span>
                                                 </p>
                                             </div>
                                         </div>

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/SwapQuote/DetailedEstimates.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/SwapQuote/DetailedEstimates.tsx
@@ -82,7 +82,7 @@ export const GasFee = ({ values, quote }: { values: SwapValues, quote: SwapQuote
     const gasFeeInUsd = gasData?.gas && gasTokenPriceInUsd ? gasData.gas * gasTokenPriceInUsd : null
     const displayGasFeeInUsd = gasFeeInUsd != null ? (gasFeeInUsd < 0.01 ? '<$0.01' : `$${gasFeeInUsd.toFixed(2)}`) : null
     const gas = gasData?.gas
-    const gasCurrencyName = gasData?.token?.symbol
+    const gasCurrencyName = gasData?.token?.asset
 
     const gaslessEnabled = useGaslessPreferenceStore(s => s.gaslessEnabled)
     const setGaslessEnabled = useGaslessPreferenceStore(s => s.setGaslessEnabled)
@@ -171,7 +171,7 @@ const Fees = ({ quote, values }: { quote: SwapQuote | undefined, values: SwapVal
             ? (discountedFeeInUsd < 0.01 ? '<$0.01' : `$${discountedFeeInUsd.toFixed(2)}`)
             : null)
 
-    const currencyName = values.fromAsset?.symbol || ''
+    const currencyName = values.fromAsset?.asset || ''
     const displayLsFee = discountedFee !== undefined
         ? truncateDecimals(discountedFee, values.fromAsset?.decimals)
         : undefined
@@ -217,7 +217,7 @@ const Reward = ({ reward }: { reward: QuoteReward }) => {
             </TooltipTrigger>
             <TooltipContent className="bg-secondary-300! border-secondary-300! text-primart-text!">
                 <span>{reward?.amount || '-'} </span>
-                <span>{reward?.amount ? reward.token.symbol : ''}</span>
+                <span>{reward?.amount ? reward.token.asset : ''}</span>
             </TooltipContent>
         </Tooltip>
     </RowWrapper>
@@ -247,7 +247,7 @@ const ExchangeTokenContract = ({ fromAsset, network }: { fromAsset: NetworkRoute
         return shortenString(fromAsset.contract)
     }, [fromAsset?.contract, network])
 
-    return <RowWrapper title={`${network?.display_name} - ${fromAsset?.symbol}`}>
+    return <RowWrapper title={`${network?.display_name} - ${fromAsset?.asset}`}>
         {
             isValidAddress && fromAsset?.contract && network ? (
                 <div className="text-sm group/addressItem text-secondary-text">

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/SwapQuote/SummaryRow.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/SwapQuote/SummaryRow.tsx
@@ -78,7 +78,7 @@ export const SummaryRow: FC<{
                 </div>
                 <div className="text-right text-primary-text h-5">
                     {quoteData?.quote?.min_receive_amount !== undefined && !isNaN(quoteData?.quote?.min_receive_amount) && (
-                        <NumFlowWithFallback value={quoteData?.quote?.min_receive_amount} trend={0} format={{ maximumFractionDigits: quoteData?.quote.destination_token?.decimals || 2 }} suffix={` ${values?.toAsset?.symbol}`} />
+                        <NumFlowWithFallback value={quoteData?.quote?.min_receive_amount} trend={0} format={{ maximumFractionDigits: quoteData?.quote.destination_token?.decimals || 2 }} suffix={` ${values?.toAsset?.asset}`} />
                     )}
                 </div>
             </div>

--- a/packages/widget/core/src/components/Pages/Swap/Form/FormWrapper.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FormWrapper.tsx
@@ -268,9 +268,9 @@ const handleCreateSwap = async ({ query, values, partner, setShowSwapModal, crea
             setShowConnectNetworkModal(true);
         } else if (data?.code === LSAPIKnownErrorCode.NETWORK_CURRENCY_DAILY_LIMIT_REACHED) {
             if (data.metadata.AvailableTransactionAmount) {
-                throw new Error(`Daily limit of ${values.fromAsset?.symbol} transfers from ${values.from?.display_name} is reached. Please try sending up to ${data.metadata.AvailableTransactionAmount} ${values.fromAsset?.symbol}.`)
+                throw new Error(`Daily limit of ${values.fromAsset?.asset} transfers from ${values.from?.display_name} is reached. Please try sending up to ${data.metadata.AvailableTransactionAmount} ${values.fromAsset?.asset}.`)
             } else {
-                throw new Error(`Daily limit of ${values.fromAsset?.symbol} transfers from ${values.from?.display_name} is reached.`)
+                throw new Error(`Daily limit of ${values.fromAsset?.asset} transfers from ${values.from?.display_name} is reached.`)
             }
         } else if (data?.code === "QUOTE_REQUIRES_NO_DEPOSIT_ADDRESS") {
             throw new Error("This route isn't available with a deposit address. Try a different source or destination.")

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/ManualWithdraw.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/ManualWithdraw.tsx
@@ -131,7 +131,7 @@ const ManualWithdraw: FC<Props> = ({ swapBasicData, depositActions, refuel, part
 
     const requestAmount = (
         <span className='inline-flex items-center gap-1 px-1.5 bg-secondary-300 rounded-lg whitespace-nowrap'>
-            <span>{truncateDecimals(Number(swapBasicData?.requested_amount), swapBasicData?.source_token?.precision)}</span> <span>{swapBasicData?.source_token?.symbol}</span>
+            <span>{truncateDecimals(Number(swapBasicData?.requested_amount), swapBasicData?.source_token?.precision)}</span> <span>{swapBasicData?.source_token?.asset}</span>
             <CopyButton toCopy={swapBasicData?.requested_amount} iconClassName='text-secondary-text' />
         </span>
     )
@@ -292,7 +292,7 @@ const ManualWithdraw: FC<Props> = ({ swapBasicData, depositActions, refuel, part
                                 number={3}
                                 label={
                                     <span className='flex items-center gap-1'>
-                                        <span>Receive</span> <span>{truncateDecimals(quote?.receive_amount ?? 0, swapBasicData?.destination_token?.precision)}</span> <span>{swapBasicData?.destination_token?.symbol}</span> <span>at</span> <span>{destinationNetwork}</span>
+                                        <span>Receive</span> <span>{truncateDecimals(quote?.receive_amount ?? 0, swapBasicData?.destination_token?.precision)}</span> <span>{swapBasicData?.destination_token?.asset}</span> <span>at</span> <span>{destinationNetwork}</span>
                                     </span>
                                 }
                                 value={

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Processing/Processing.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Processing/Processing.tsx
@@ -224,15 +224,15 @@ const Processing: FC<Props> = ({ swapBasicData, swapDetails, quote, refuel, fail
         },
         "output_transfer": {
             upcoming: {
-                name: isDepositFlow ? 'Completing your deposit' : `Sending ${destination_token.symbol} to your address`,
+                name: isDepositFlow ? 'Completing your deposit' : `Sending ${destination_token.asset} to your address`,
                 description: null
             },
             current: {
-                name: isDepositFlow ? 'Completing your deposit' : `Sending ${destination_token.symbol} to your address`,
+                name: isDepositFlow ? 'Completing your deposit' : `Sending ${destination_token.asset} to your address`,
                 description: null
             },
             complete: {
-                name: `${swapOutputTransaction?.amount && truncateDecimals(swapOutputTransaction?.amount, destination_token.decimals)} ${destination_token.symbol} ${isDepositFlow ? 'deposited' : 'was sent to your address'}`,
+                name: `${swapOutputTransaction?.amount && truncateDecimals(swapOutputTransaction?.amount, destination_token.decimals)} ${destination_token.asset} ${isDepositFlow ? 'deposited' : 'was sent to your address'}`,
                 description: swapOutputTransaction?.amount ? <div className="flex flex-col">
                     <div>
                         <span>Transaction: </span>{' '}
@@ -272,15 +272,15 @@ const Processing: FC<Props> = ({ swapBasicData, swapDetails, quote, refuel, fail
         },
         "refuel": {
             upcoming: {
-                name: `Sending ${refuel?.token?.symbol} to your address`,
+                name: `Sending ${refuel?.token?.asset} to your address`,
                 description: null
             },
             current: {
-                name: `Sending ${refuel?.token?.symbol} to your address`,
+                name: `Sending ${refuel?.token?.asset} to your address`,
                 description: null
             },
             complete: {
-                name: `${truncatedRefuelAmount} ${refuel?.token?.symbol} was sent to your address`,
+                name: `${truncatedRefuelAmount} ${refuel?.token?.asset} was sent to your address`,
                 description: <div>
                     <span>Transaction: </span>{' '}
                     {swapRefuelTransaction &&
@@ -337,9 +337,9 @@ const Processing: FC<Props> = ({ swapBasicData, swapDetails, quote, refuel, fail
         swapOutputTransaction,
         swapRefuelTransaction,
         swapRefundTransaction,
-        destination_token.symbol,
+        destination_token.asset,
         destination_token.decimals,
-        refuel?.token?.symbol,
+        refuel?.token?.asset,
         truncatedRefuelAmount,
         fail_reason,
         swapDetails.status,

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/QuoteUpdate.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/QuoteUpdate.tsx
@@ -47,7 +47,7 @@ export const QuoteUpdated: FC<QuoteUpdatedProps> = (props) => {
 export async function handleLimitsUpdate(params: {
     swapValues: SwapFormValues;
     network?: { display_name: string };
-    token?: { symbol: string };
+    token?: { asset: string };
     getConfirmation: ReturnType<typeof useAsyncModal>['getConfirmation'];
 }): Promise<void> {
     const { swapValues, network, token } = params;
@@ -87,7 +87,7 @@ export async function handleLimitsUpdate(params: {
                 maxAllowedAmount={maxAllowedAmount}
                 isBelowMin={belowMin}
                 network={network?.display_name}
-                token={token?.symbol}
+                token={token?.asset}
             />
         ),
         submitText: "Continue",

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Summary/Summary.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Summary/Summary.tsx
@@ -60,10 +60,10 @@ const Summary: FC<SwapInfoProps> = (props) => {
                     primary={requestedAmount ? (isUsdMode ? (
                         <NumFlowWithFallback value={Number(requestedAmountInUsd) || 0} prefix="$" trend={0} />
                     ) : (
-                        <span>{truncateDecimals(Number(requestedAmount), sourceCurrency.precision)}{` ${sourceCurrency.symbol}`}</span>
+                        <span>{truncateDecimals(Number(requestedAmount), sourceCurrency.precision)}{` ${sourceCurrency.asset}`}</span>
                     )) : null}
                     secondary={requestedAmount ? (isUsdMode ? (
-                        <span>{truncateDecimals(Number(requestedAmount), sourceCurrency.precision)}{` ${sourceCurrency.symbol}`}</span>
+                        <span>{truncateDecimals(Number(requestedAmount), sourceCurrency.precision)}{` ${sourceCurrency.asset}`}</span>
                     ) : (
                         <NumFlowWithFallback value={Number(requestedAmountInUsd) || 0} prefix="$" trend={0} />
                     )) : null}
@@ -78,13 +78,13 @@ const Summary: FC<SwapInfoProps> = (props) => {
                     primary={receiveAmount ? (isUsdMode ? (
                         <NumFlowWithFallback value={Number(receiveAmountInUsd) || 0} prefix="$" trend={0} />
                     ) : (
-                        <NumFlowWithFallback value={Number(receiveAmount) || 0} suffix={` ${destinationCurrency.symbol}`} trend={0} format={{ maximumFractionDigits: quote.quote.destination_token?.decimals || 2 }} />
+                        <NumFlowWithFallback value={Number(receiveAmount) || 0} suffix={` ${destinationCurrency.asset}`} trend={0} format={{ maximumFractionDigits: quote.quote.destination_token?.decimals || 2 }} />
                     )) : null}
                     secondary={receiveAmount ? (
                         <>
                             <PriceImpact className="text-sm" quote={swapQuote} refuel={refuel} />
                             {isUsdMode ? (
-                                <NumFlowWithFallback value={Number(receiveAmount) || 0} suffix={` ${destinationCurrency.symbol}`} trend={0} format={{ maximumFractionDigits: quote.quote.destination_token?.decimals || 2 }} />
+                                <NumFlowWithFallback value={Number(receiveAmount) || 0} suffix={` ${destinationCurrency.asset}`} trend={0} format={{ maximumFractionDigits: quote.quote.destination_token?.decimals || 2 }} />
                             ) : (
                                 <NumFlowWithFallback value={Number(receiveAmountInUsd) || 0} prefix="$" trend={0} />
                             )}
@@ -101,7 +101,7 @@ const Summary: FC<SwapInfoProps> = (props) => {
                                 <p>Refuel</p>
                             </div>
                             <div className="flex flex-col items-end">
-                                <p className="text-primary-text text-sm">{truncatedRefuelAmount} {nativeCurrency?.symbol}</p>
+                                <p className="text-primary-text text-sm">{truncatedRefuelAmount} {nativeCurrency?.asset}</p>
                                 <p className="text-secondary-text text-sm flex justify-end">${refuelAmountInUsd}</p>
                             </div>
                         </div>
@@ -148,7 +148,7 @@ const SwapRow: FC<SwapRowProps> = ({ route, token, primary, secondary }) => {
             </div>
             <div className="flex flex-col grow min-w-0">
                 <div className="flex items-center gap-2 h-8">
-                    <p className="text-primary-text text-xl leading-6 font-normal grow truncate min-w-0">{token.symbol}</p>
+                    <p className="text-primary-text text-xl leading-6 font-normal grow truncate min-w-0">{token.asset}</p>
                     <div className="text-primary-text text-xl leading-6 font-normal flex items-center justify-end shrink-0 whitespace-nowrap">{primary}</div>
                 </div>
                 <div className="flex items-center gap-2 h-5">

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Wallet/Common/buttons.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Wallet/Common/buttons.tsx
@@ -374,7 +374,7 @@ export const SendTransactionButton: FC<SendFromWalletButtonProps> = ({
                     <span className="shrink-0"><InfoIcon className="w-5 h-5 text-warning-foreground" /></span>
                     <div className="flex flex-col gap-1.5 pr-4">
                         <p className="text-white font-semibold leading-4 text-base mt-0.5">Critical receiving amount</p>
-                        <p className="text-priamry-text text-base font-normal leading-4.5"><span>By continuing, you agree to receive as low as </span><span className="text-warning-foreground text-nowrap">{quote.min_receive_amount} {quote.destination_token?.symbol} ($ {priceImpactValues.minReceiveAmountUSD})</span></p>
+                        <p className="text-priamry-text text-base font-normal leading-4.5"><span>By continuing, you agree to receive as low as </span><span className="text-warning-foreground text-nowrap">{quote.min_receive_amount} {quote.destination_token?.asset} ($ {priceImpactValues.minReceiveAmountUSD})</span></p>
                     </div>
                 </div>
             </div>}
@@ -407,7 +407,7 @@ export const SendTransactionButton: FC<SendFromWalletButtonProps> = ({
                     <span className="shrink-0"><InfoIcon className="w-5 h-5 text-warning-foreground" /></span>
                     <div className="flex flex-col gap-1.5 pr-4">
                         <p className="text-primary-text font-medium leading-4 text-base mt-0.5">Critical receiving amount</p>
-                        <p className="text-secondary-text text-sm leading-4.5"><span>The “receive at least” amount is affected by high price impact. You will receive at least </span><span>{quote.min_receive_amount} {quote.destination_token?.symbol} ($ {priceImpactValues.minReceiveAmountUSD}) </span></p>
+                        <p className="text-secondary-text text-sm leading-4.5"><span>The “receive at least” amount is affected by high price impact. You will receive at least </span><span>{quote.min_receive_amount} {quote.destination_token?.asset} ($ {priceImpactValues.minReceiveAmountUSD}) </span></p>
                     </div>
                 </div>
             </div>}

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Wallet/RPCUnhealthyMessage.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Wallet/RPCUnhealthyMessage.tsx
@@ -34,7 +34,7 @@ const RPCUnhealthyMessage: FC<Props> = ({ network, suggestRpcForCurrentChain, is
             chainName: network.display_name,
             nativeCurrency: {
                 name: network.display_name,
-                symbol: network.token?.symbol,
+                symbol: network.token?.asset,
                 decimals: network.token?.decimals
             }
         })

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/WalletTransferContent.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/WalletTransferContent.tsx
@@ -69,7 +69,7 @@ const WalletTransferContent: FC<Props> = ({ openModal, setOpenModal, swapData })
                     />
                     <div className="flex flex-col col-start-8 col-span-3 items-end font-normal text-secondary-text text-xs">
                         <p>Balance</p>
-                        <p className='flex items-center gap-1'><span>{truncateDecimals(Number(walletBalanceAmount), walletBalance?.decimals)}</span> <span>{walletBalance?.token}</span></p>
+                        <p className='flex items-center gap-1'><span>{truncateDecimals(Number(walletBalanceAmount), walletBalance?.decimals)}</span> <span>{source_token?.asset}</span></p>
                     </div>
                 </div>
             }

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/Withdraw.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/Withdraw.tsx
@@ -90,10 +90,10 @@ const Withdraw: FC<{ type: 'widget' | 'contained', onWalletWithdrawalSuccess?: (
                 icon={<InfoIcon className={ICON_CLASSES_WARNING} />}
                 title={<>
                     <span>{"Insufficient balance"}</span>
-                    {balanceAmount && swapBasicData?.source_token?.symbol && (
+                    {balanceAmount && swapBasicData?.source_token?.asset && (
                         <span
                             className={`font-normal text-sm ${showSpinner ? 'animate-shine bg-[linear-gradient(90deg,var(--color-secondary-text)_40%,white_50%,var(--color-secondary-text)_60%)] bg-size-[200%_100%] bg-clip-text text-transparent' : 'text-secondary-text'}`}
-                        > ({balanceAmount} {swapBasicData.source_token.symbol})</span>
+                        > ({balanceAmount} {swapBasicData.source_token.asset})</span>
                     )}
                 </>}
                 message="If you recently added funds, refresh the balance or check your connected wallet"

--- a/packages/widget/core/src/components/Pages/Swap/Withdraw/WithdrawalProviders/Hyperliquid/useHyperliquidWithdrawal.ts
+++ b/packages/widget/core/src/components/Pages/Swap/Withdraw/WithdrawalProviders/Hyperliquid/useHyperliquidWithdrawal.ts
@@ -129,7 +129,7 @@ export function useHyperliquidWithdrawal({ swapBasicData, refuel, swapId }: With
             const amount = swapBasicData.requested_amount.toString().trim()
             const decimals = source_token.decimals ?? 6
             const amountPattern = decimals > 0 ? new RegExp(`^\\d+(\\.\\d{1,${decimals}})?$`) : /^\d+$/
-            if (!amountPattern.test(amount)) throw new Error(`Invalid amount — at most ${decimals} decimal places for ${source_token.symbol}`)
+            if (!amountPattern.test(amount)) throw new Error(`Invalid amount — at most ${decimals} decimal places for ${source_token.asset}`)
             const A = Number(amount)
             if (!Number.isFinite(A) || A <= 0) throw new Error('Invalid amount')
 

--- a/packages/widget/core/src/components/Pages/SwapHistory/HistorySummary.tsx
+++ b/packages/widget/core/src/components/Pages/SwapHistory/HistorySummary.tsx
@@ -53,7 +53,7 @@ const HistorySummary: FC<SwapInfoProps> = ({
                             <div className="h-[30px] w-[30px] rounded-full overflow-hidden">
                                 <ImageWithFallback
                                     src={source_token.logo}
-                                    alt={`${source_token.symbol} logo`}
+                                    alt={`${source_token.asset} logo`}
                                     width={30}
                                     height={30}
                                     className="rounded-full"
@@ -85,7 +85,7 @@ const HistorySummary: FC<SwapInfoProps> = ({
                                     </TooltipContent>
                                 </Tooltip>
 
-                                <span className="shrink-0">{source_token.symbol}</span>
+                                <span className="shrink-0">{source_token.asset}</span>
                             </div>
 
                             <span className="text-secondary-text text-sm text-left leading-3.5">
@@ -114,7 +114,7 @@ const HistorySummary: FC<SwapInfoProps> = ({
                                     </TooltipContent>
                                 </Tooltip>
 
-                                <span className="shrink-0">{destination_token.symbol}</span>
+                                <span className="shrink-0">{destination_token.asset}</span>
                             </div>
 
                             <span className="text-secondary-text text-sm text-right leading-3.5">
@@ -126,7 +126,7 @@ const HistorySummary: FC<SwapInfoProps> = ({
                             <div className="h-[30px] w-[30px] rounded-full overflow-hidden">
                                 <ImageWithFallback
                                     src={destination_token.logo}
-                                    alt={`${destination_token.symbol} logo`}
+                                    alt={`${destination_token.asset} logo`}
                                     width={30}
                                     height={30}
                                     className="rounded-full"

--- a/packages/widget/core/src/components/Wallet/WalletComponents/WalletsList.tsx
+++ b/packages/widget/core/src/components/Wallet/WalletComponents/WalletsList.tsx
@@ -214,7 +214,7 @@ export const WalletItem: FC<WalletItemProps> = ({ selectable, account: item, net
                                                             <div className='h-[14px] w-20 inline-flex bg-gray-500 rounded-xs animate-pulse' />
                                                             :
                                                             <>
-                                                                <span>{walletBalanceAmount}</span> <span>{token?.symbol}</span>
+                                                                <span>{walletBalanceAmount}</span> <span>{token?.asset}</span>
                                                             </>
                                                     }
                                                 </div>
@@ -382,7 +382,7 @@ const NestedWalletAddress: FC<NestedWalletAddressProps> = ({ selectable, address
                                         <div className="h-[14px] w-20 inline-flex bg-gray-500 rounded-sm animate-pulse" />
                                     ) : (
                                         <>
-                                            <span>{nestedWalletBalanceAmount}</span> <span>{token?.symbol}</span>
+                                            <span>{nestedWalletBalanceAmount}</span> <span>{token?.asset}</span>
                                         </>
                                     )
                                 }

--- a/packages/widget/core/src/helpers/filterSourceNetworks.ts
+++ b/packages/widget/core/src/helpers/filterSourceNetworks.ts
@@ -16,7 +16,7 @@ export function filterSourceNetworks(settings: LayerSwapSettings, walletProvider
     const allNetworkTypes = Object.keys(networkTypesAggregation)
 
     const availableNetworkTypes = allNetworkTypes.filter(networkType => {
-        return networkTypesAggregation[networkType].some(route => route.deposit_methods.includes("deposit_address") ||
+        return networkTypesAggregation[networkType].some(route => route?.deposit_methods?.includes("deposit_address") ||
             walletProviders.some(provider => provider.withdrawalSupportedNetworks.includes(route.name))
         )
     })

--- a/packages/widget/core/src/hooks/useFormRoutes.ts
+++ b/packages/widget/core/src/hooks/useFormRoutes.ts
@@ -291,7 +291,7 @@ function sortTokensByMostUsed(
         if (bUsage !== aUsage) {
             return bUsage - aUsage;
         }
-        return a.symbol.localeCompare(b.symbol);
+        return a.asset.localeCompare(b.asset);
     });
 }
 
@@ -307,7 +307,7 @@ function sortTokensByTrending(
         if (aRank !== bRank) {
             return aRank - bRank;
         }
-        return a.symbol.localeCompare(b.symbol);
+        return a.asset.localeCompare(b.asset);
     });
 }
 
@@ -316,7 +316,7 @@ function sortTokensAlphabetically(
     ascending: boolean = true
 ): NetworkRouteToken[] {
     return [...tokens].sort((a, b) => {
-        const comparison = a.symbol.localeCompare(b.symbol);
+        const comparison = a.asset.localeCompare(b.asset);
         return ascending ? comparison : -comparison;
     });
 }
@@ -376,7 +376,7 @@ function sortGroupedTokens(
             return groupsWithSortedItems.sort((a, b) => {
                 const aUsage = symbolUsageMap.get(a.symbol) || 0;
                 const bUsage = symbolUsageMap.get(b.symbol) || 0;
-                return bUsage - aUsage || a.symbol.localeCompare(b.symbol);
+                return bUsage - aUsage || a.asset.localeCompare(b.asset);
             });
         }
         case 'trending': {
@@ -385,12 +385,12 @@ function sortGroupedTokens(
                 ...g,
                 minRank: g.items.reduce((min, i) => Math.min(min, i.route.token[rankKey] || 999999), 999999),
             }));
-            return withMinRank.sort((a, b) => a.minRank - b.minRank || a.symbol.localeCompare(b.symbol));
+            return withMinRank.sort((a, b) => a.minRank - b.minRank || a.asset.localeCompare(b.asset));
         }
         case 'alphabetical_asc':
-            return groupsWithSortedItems.sort((a, b) => a.symbol.localeCompare(b.symbol));
+            return groupsWithSortedItems.sort((a, b) => a.asset.localeCompare(b.asset));
         case 'alphabetical_desc':
-            return groupsWithSortedItems.sort((a, b) => b.symbol.localeCompare(a.symbol));
+            return groupsWithSortedItems.sort((a, b) => b.asset.localeCompare(a.asset));
         default:
             return groupsWithSortedItems;
     }
@@ -496,7 +496,7 @@ function sortTokensByRelevance(
         const bRank = b[rankKey] || 999999;
         if (aRank !== bRank) return aRank - bRank;
 
-        return a.symbol.localeCompare(b.symbol);
+        return a.asset.localeCompare(b.asset);
     });
 }
 
@@ -532,7 +532,7 @@ function sortGroupedTokensByRelevance(
 
         if (a.minRank !== b.minRank) return a.minRank - b.minRank;
 
-        return a.symbol.localeCompare(b.symbol);
+        return a.asset.localeCompare(b.asset);
     });
 }
 
@@ -598,6 +598,7 @@ const searchInTokens = (routes: NetworkRoute[], search: string): NetworkTokenEle
     return extractTokenElementsAsSuggested(routes).filter(e => {
         const { token, route } = e.route;
 
+        const assetMatch = token.asset.toLowerCase().includes(lower);
         const symbolMatch = token.symbol.toLowerCase().includes(lower);
         const contractMatch = token.contract?.toLowerCase().includes(lower);
         const nameMatch = token.display_asset?.toLowerCase().includes(lower);
@@ -606,16 +607,16 @@ const searchInTokens = (routes: NetworkRoute[], search: string): NetworkTokenEle
         const secondpart = splitted?.[1]
 
         const combo = (firstpart && secondpart) ? (
-            (token.symbol.toLowerCase().includes(firstpart) && route.name.toLowerCase().includes(secondpart))
+            (token.asset.toLowerCase().includes(firstpart) && route.name.toLowerCase().includes(secondpart))
             ||
-            (token.symbol.toLowerCase().includes(secondpart) && route.name.toLowerCase().includes(firstpart))
+            (token.asset.toLowerCase().includes(secondpart) && route.name.toLowerCase().includes(firstpart))
             ||
-            (token.symbol.toLowerCase().includes(firstpart) && route.display_name.toLowerCase().includes(secondpart))
+            (token.asset.toLowerCase().includes(firstpart) && route.display_name.toLowerCase().includes(secondpart))
             ||
-            (token.symbol.toLowerCase().includes(secondpart) && route.display_name.toLowerCase().includes(firstpart))
+            (token.asset.toLowerCase().includes(secondpart) && route.display_name.toLowerCase().includes(firstpart))
         ) : false
 
-        return symbolMatch || contractMatch || nameMatch || combo;
+        return assetMatch || symbolMatch || contractMatch || nameMatch || combo;
     });
 };
 // ---------- Route Grouping ----------
@@ -746,6 +747,7 @@ function groupByTokens(routes: NetworkRoute[]): GroupedTokenElement[] {
         .map(([symbol, items]) => ({
             type: 'grouped_token',
             symbol,
+            asset: items[0]?.route.token.asset ?? symbol,
             items
         }));
     return result;
@@ -764,7 +766,7 @@ function sortNetworkTokens(
             return balanceB - balanceA; // Descending by balance
         }
 
-        return a.symbol.localeCompare(b.symbol); // Ascending by symbol
+        return a.asset.localeCompare(b.asset); // Ascending by display asset
     });
 }
 

--- a/packages/widget/core/src/lib/generateSwapInitialValues.ts
+++ b/packages/widget/core/src/lib/generateSwapInitialValues.ts
@@ -66,7 +66,7 @@ export function generateSwapInitialValues(settings: LayerSwapAppSettings, queryP
 
     let initialSourceCurrency = filteredSourceCurrencies?.find(c => c.symbol?.toUpperCase() == fromAsset?.toUpperCase())
     if (!initialSourceCurrency && !fromAsset && sourceNetwork) {
-        initialSourceCurrency = filteredSourceCurrencies?.sort((a, b) => a.symbol.localeCompare(b.symbol))?.find(c => c.status === "active")
+        initialSourceCurrency = filteredSourceCurrencies?.sort((a, b) => a.asset.localeCompare(b.asset))?.find(c => c.status === "active")
     }
 
     let initialDestinationCurrency = filteredDestinationCurrencies?.find(c => c.symbol?.toUpperCase() == toAsset?.toUpperCase())
@@ -77,7 +77,7 @@ export function generateSwapInitialValues(settings: LayerSwapAppSettings, queryP
                 ?.filter(c => c.status === "active")
                 ?.sort((a, b) => rank(a) - rank(b))[0];
         } else {
-            initialDestinationCurrency = filteredDestinationCurrencies?.sort((a, b) => a.symbol.localeCompare(b.symbol))?.find(c => c.status === "active")
+            initialDestinationCurrency = filteredDestinationCurrencies?.sort((a, b) => a.asset.localeCompare(b.asset))?.find(c => c.status === "active")
         }
     }
 

--- a/packages/widget/core/src/lib/walletNetworkAdapter.ts
+++ b/packages/widget/core/src/lib/walletNetworkAdapter.ts
@@ -11,7 +11,7 @@ export const walletNetworkAdapter = defineNetworkAdapter<NetworkWithTokens>({
     getTransactionExplorerUrl: network => network.transaction_explorer_template,
     getAccountExplorerUrl: network => network.account_explorer_template,
     getNativeCurrency: network => network.token && {
-        symbol: network.token.symbol,
+        symbol: network.token.asset,
         decimals: network.token.decimals,
     },
     getMulticallAddress: network => network.metadata?.evm_multicall_contract ?? undefined,

--- a/packages/widget/types/src/network.ts
+++ b/packages/widget/types/src/network.ts
@@ -13,7 +13,10 @@ export enum NetworkType {
 }
 
 type RefuelToken = {
+  /** Canonical identifier used in Layerswap API requests and lookups. */
   symbol: string;
+  /** User-facing ticker used in labels and messages. */
+  asset: string;
   display_asset?: string;
   logo: string;
   contract: string | null | undefined;

--- a/packages/widget/types/src/types.ts
+++ b/packages/widget/types/src/types.ts
@@ -22,7 +22,10 @@ export class NetworkWithTokens extends Network {
 }
 
 export class Token {
+    /** Canonical identifier used in Layerswap API requests and lookups. */
     symbol: string;
+    /** User-facing ticker used in labels and messages. */
+    asset: string;
     display_asset?: string;
     logo: string;
     //TODO may be plain string


### PR DESCRIPTION
## Summary

- add asset to shared token and refuel models
- use asset for user-facing token labels, search ordering, wallet metadata, Explorer, and playground UI
- keep symbol for API requests, balance and route matching, and persisted token identity
- set asset explicitly on synthesized Polymarket tokens

## Verification

- pnpm -r --if-present check:types
- pnpm --filter @layerswap/widget build
- verified all 822 live /api/v2/networks token objects include asset