### PR TITLE
fix(stellar): build deposit invocations with the connected wallet

### DIFF
--- a/.changeset/stellar-wallet-deposit-invocation.md
+++ b/.changeset/stellar-wallet-deposit-invocation.md
@@ -1,0 +1,5 @@
+---
+"@layerswap/wallet-stellar": patch
+---
+
+Build Stellar deposits from the API's four encoded arguments and the connected wallet address. Deposit actions no longer require call data or a source address; prepared transaction and authorization validation remain enforced.

--- a/packages/wallets/adapters/stellar/src/transferProvider/createStellarTransfer.ts
+++ b/packages/wallets/adapters/stellar/src/transferProvider/createStellarTransfer.ts
@@ -5,7 +5,7 @@ import { ActionMessageType, NetworkType, type TransferProvider } from '@layerswa
 import { resolveStellarNetworkPassphrase } from '../stellarNetwork'
 import { getStellarHorizonServer, getStellarRpcServer } from '../stellarServers'
 import { stellarKitManager } from '../service/stellarKitManager'
-import { validateStellarOperationXdr, validateStellarXdr } from './validateStellarXdr'
+import { buildStellarDepositOperation, validateStellarXdr } from './validateStellarXdr'
 
 const TRANSACTION_TIMEOUT_SECONDS = 5 * 60
 
@@ -54,26 +54,19 @@ export function createStellarTransfer(): TransferProvider {
                 depositAddress,
                 network,
                 token,
-                callData,
                 amountInBaseUnits,
                 encodedArgs,
                 sequenceNumber,
-                sourceAddress,
             } = params
             if (!selectedWallet?.address) throw new Error('Stellar wallet address not found')
             if (!depositAddress) throw new Error('Stellar depository contract not found')
             if (!amountInBaseUnits) throw new Error('Stellar deposit amount is missing')
             if (!encodedArgs) throw new Error('Stellar deposit encoded_args are missing')
             if (sequenceNumber === undefined) throw new Error('Stellar swap sequence number is missing')
-            if (!sourceAddress) throw new Error('Stellar deposit source address is missing')
-            if (sourceAddress !== selectedWallet.address) {
-                throw mappedError(ActionMessageType.WaletMismatch, 'The Stellar deposit action belongs to a different account')
-            }
 
             try {
                 const networkPassphrase = resolveStellarNetworkPassphrase(network)
-                const operation = validateStellarOperationXdr({
-                    operationXdr: callData,
+                const operation = buildStellarDepositOperation({
                     networkPassphrase,
                     selectedAddress: selectedWallet.address,
                     depositoryContract: depositAddress,

--- a/packages/wallets/adapters/stellar/src/transferProvider/validateStellarXdr.ts
+++ b/packages/wallets/adapters/stellar/src/transferProvider/validateStellarXdr.ts
@@ -4,6 +4,7 @@ import {
     StrKey,
     Transaction,
     TransactionBuilder,
+    nativeToScVal,
     scValToNative,
     xdr,
 } from '@stellar/stellar-sdk'
@@ -25,6 +26,11 @@ export type ValidateStellarXdrParams = {
     currentAccountSequence: string
     now?: number
 }
+
+export type BuildStellarDepositOperationParams = Omit<
+    ValidateStellarXdrParams,
+    'envelopeXdr' | 'currentAccountSequence' | 'now'
+>
 
 export type ValidateStellarOperationXdrParams = Omit<
     ValidateStellarXdrParams,
@@ -127,7 +133,7 @@ function validateExpectedArguments(params: {
     if (!StrKey.isValidEd25519PublicKey(receiver)) throw new Error('Stellar depository receiver is invalid')
     if (amount !== amountInBaseUnits) throw new Error('Stellar depository amount does not match the deposit action')
 
-    const expectedEncodedArgs = [source, depositId, assetContract, receiver, amount]
+    const expectedEncodedArgs = [depositId, assetContract, receiver, amount]
     if (
         encodedArgs.length !== expectedEncodedArgs.length
         || encodedArgs.some((value, index) => value !== expectedEncodedArgs[index])
@@ -203,6 +209,35 @@ export function validateStellarOperationXdr(params: ValidateStellarOperationXdrP
         throw new Error('Unsigned Stellar depository operation must not contain authorization entries')
     }
     return encodedOperation
+}
+
+export function buildStellarDepositOperation(params: BuildStellarDepositOperationParams): xdr.Operation {
+    const { selectedAddress, depositoryContract, encodedArgs } = params
+    validateAddresses(selectedAddress, depositoryContract)
+    if (encodedArgs.length !== 4) throw new Error('Stellar deposit must contain exactly four encoded_args')
+
+    const [depositId, tokenContract, receiver, amount] = encodedArgs
+    if (!/^[0-9a-f]{64}$/.test(depositId)) throw new Error('Stellar depository ID must be 32 hex-encoded bytes')
+    if (!/^[1-9]\d*$/.test(amount)) throw new Error('Stellar deposit amount is invalid')
+    if (!StrKey.isValidContract(tokenContract)) throw new Error('Stellar depository asset contract is invalid')
+    if (!StrKey.isValidEd25519PublicKey(receiver)) throw new Error('Stellar depository receiver is invalid')
+
+    const idBytes = Uint8Array.from({ length: 32 }, (_, index) => Number.parseInt(depositId.slice(index * 2, index * 2 + 2), 16))
+    const operation = Operation.invokeContractFunction({
+        contract: depositoryContract,
+        function: 'deposit',
+        source: selectedAddress,
+        args: [
+            new Address(selectedAddress).toScVal(),
+            nativeToScVal(idBytes),
+            new Address(tokenContract).toScVal(),
+            new Address(receiver).toScVal(),
+            nativeToScVal(BigInt(amount), { type: 'i128' }),
+        ],
+        auth: [],
+    })
+    validateDepositOperation(Operation.fromXdrObject(operation), params)
+    return operation
 }
 
 export function validateStellarXdr(params: ValidateStellarXdrParams): Transaction {

--- a/packages/wallets/adapters/stellar/tests/stellar.test.mjs
+++ b/packages/wallets/adapters/stellar/tests/stellar.test.mjs
@@ -5,6 +5,8 @@ import {
     Address,
     Asset,
     Keypair,
+    Horizon,
+    rpc,
     Memo,
     Networks,
     Operation,
@@ -28,6 +30,7 @@ import {
     getStellarRpcServer,
 } from '../dist/esm/stellarServers.js'
 import {
+    buildStellarDepositOperation,
     validateStellarOperationXdr,
     validateStellarXdr,
 } from '../dist/esm/transferProvider/validateStellarXdr.js'
@@ -43,6 +46,8 @@ import {
 import { StellarConnectionService } from '../dist/esm/service/StellarConnectionService.js'
 import { toStellarConnector } from '../dist/esm/service/stellarConnector.js'
 import { stellarStore } from '../dist/esm/service/stellarStore.js'
+import { stellarKitManager } from '../dist/esm/service/stellarKitManager.js'
+import { createStellarTransfer } from '../dist/esm/transferProvider/createStellarTransfer.js'
 
 const sourceKey = Keypair.random()
 const receiverKey = Keypair.random()
@@ -147,7 +152,6 @@ function buildFixture({
         token,
         depository,
         encodedArgs: [
-            sourceKey.publicKey(),
             Buffer.from(depositIdBytes(depositId)).toString('hex'),
             tokenContract,
             receiver,
@@ -158,46 +162,17 @@ function buildFixture({
     }
 }
 
-function buildOperationFixture({
-    networkPassphrase = Networks.TESTNET,
-    token = nativeToken,
-    depository = depositoryContract,
-    receiver = receiverKey.publicKey(),
-    amount = amountInBaseUnits,
-    depositId = swapSequenceNumber,
-    source = sourceKey.publicKey(),
-    auth = [],
-} = {}) {
-    const tokenContract = resolveStellarAsset(token).contractId(networkPassphrase)
-    const args = [
-        new Address(sourceKey.publicKey()).toScVal(),
-        nativeToScVal(depositIdBytes(depositId)),
-        new Address(tokenContract).toScVal(),
-        new Address(receiver).toScVal(),
-        nativeToScVal(BigInt(amount), { type: 'i128' }),
-    ]
-    const operation = Operation.invokeContractFunction({
-        contract: depository,
-        function: 'deposit',
-        args,
-        auth,
-        source,
+function buildDepositOperation(fixture, overrides = {}) {
+    return buildStellarDepositOperation({
+        networkPassphrase: fixture.networkPassphrase,
+        selectedAddress: sourceKey.publicKey(),
+        depositoryContract: fixture.depository,
+        token: fixture.token,
+        amountInBaseUnits: fixture.amount,
+        encodedArgs: fixture.encodedArgs,
+        swapSequenceNumber: fixture.depositId,
+        ...overrides,
     })
-    return {
-        operationXdr: operation.toXdr('base64'),
-        networkPassphrase,
-        token,
-        depository,
-        encodedArgs: [
-            sourceKey.publicKey(),
-            Buffer.from(depositIdBytes(depositId)).toString('hex'),
-            tokenContract,
-            receiver,
-            amount,
-        ],
-        amount,
-        depositId,
-    }
 }
 
 function validateFixture(fixture, overrides = {}) {
@@ -260,49 +235,135 @@ test('validates native and issued-asset depository XDR on both networks', () => 
     assert.equal(validateFixture(issued).source, sourceKey.publicKey())
 })
 
-test('validates backend Stellar depository operation XDR before simulation', () => {
-    const native = buildOperationFixture()
-    const parsedNative = validateStellarOperationXdr({
-        operationXdr: native.operationXdr,
-        networkPassphrase: native.networkPassphrase,
-        selectedAddress: sourceKey.publicKey(),
-        depositoryContract: native.depository,
-        token: native.token,
-        amountInBaseUnits: native.amount,
-        encodedArgs: native.encodedArgs,
-        swapSequenceNumber: native.depositId,
-    })
-    assert.equal(Operation.fromXdrObject(parsedNative).source, sourceKey.publicKey())
+test('builds native and issued-asset deposits from four arguments with the connected wallet as from', () => {
+    for (const fixture of [buildFixture(), buildFixture({ networkPassphrase: Networks.PUBLIC, token: issuedToken })]) {
+        const encodedOperation = buildDepositOperation(fixture)
+        const operation = Operation.fromXdrObject(encodedOperation)
+        assert.equal(operation.source, sourceKey.publicKey())
+        assert.equal(operation.func.type, 'hostFunctionTypeInvokeContract')
+        const invocation = operation.func.invokeContract
+        assert.equal(Address.fromScAddress(invocation.contractAddress).toString(), fixture.depository)
+        assert.equal(invocation.functionName.toString(), 'deposit')
+        assert.equal(invocation.args.length, 5)
+        assert.equal(Address.fromScVal(invocation.args[0]).toString(), sourceKey.publicKey())
+        assert.deepEqual(invocation.args.map(arg => arg.toXdr('base64')),
+            fixture.transaction.operations[0].func.invokeContract.args.map(arg => arg.toXdr('base64')))
+        assert.deepEqual(operation.auth, [])
+        const operationParams = {
+            networkPassphrase: fixture.networkPassphrase,
+            selectedAddress: sourceKey.publicKey(),
+            depositoryContract: fixture.depository,
+            token: fixture.token,
+            amountInBaseUnits: fixture.amount,
+            encodedArgs: fixture.encodedArgs,
+            swapSequenceNumber: fixture.depositId,
+        }
+        assert.doesNotThrow(() => validateStellarOperationXdr({
+            ...operationParams,
+            operationXdr: encodedOperation.toXdr('base64'),
+        }))
+        const authorized = Operation.invokeContractFunction({
+            contract: fixture.depository,
+            function: 'deposit',
+            source: sourceKey.publicKey(),
+            args: invocation.args,
+            auth: fixture.transaction.operations[0].auth,
+        })
+        assert.throws(() => validateStellarOperationXdr({
+            ...operationParams,
+            operationXdr: authorized.toXdr('base64'),
+        }), /must not contain authorization entries/)
 
-    const issued = buildOperationFixture({ networkPassphrase: Networks.PUBLIC, token: issuedToken })
-    assert.doesNotThrow(() => validateStellarOperationXdr({
-        operationXdr: issued.operationXdr,
-        networkPassphrase: issued.networkPassphrase,
-        selectedAddress: sourceKey.publicKey(),
-        depositoryContract: issued.depository,
-        token: issued.token,
-        amountInBaseUnits: issued.amount,
-        encodedArgs: issued.encodedArgs,
-        swapSequenceNumber: issued.depositId,
-    }))
+        const otherSource = Keypair.random().publicKey()
+        const switched = Operation.fromXdrObject(buildDepositOperation(fixture, { selectedAddress: otherSource }))
+        assert.equal(switched.source, otherSource)
+        assert.equal(Address.fromScVal(switched.func.invokeContract.args[0]).toString(), otherSource)
+    }
+})
 
-    const authorized = buildOperationFixture({
-        auth: createAuthorization({
-            depository: native.depository,
-            tokenContract: native.encodedArgs[2],
-            args: Operation.fromXdrObject(parsedNative).func.invokeContract.args,
-        }),
+test('prepares, signs and submits a deposit without API call_data or from_address', async t => {
+    const fixture = buildFixture()
+    const calls = []
+    t.mock.method(Horizon.Server.prototype, 'root', async () => ({ network_passphrase: fixture.networkPassphrase }))
+    t.mock.method(rpc.Server.prototype, 'getNetwork', async () => ({ passphrase: fixture.networkPassphrase }))
+    t.mock.method(Horizon.Server.prototype, 'loadAccount', async address => {
+        assert.equal(address, sourceKey.publicKey())
+        return new Account(address, sourceSequence)
     })
-    assert.throws(() => validateStellarOperationXdr({
-        operationXdr: authorized.operationXdr,
-        networkPassphrase: authorized.networkPassphrase,
-        selectedAddress: sourceKey.publicKey(),
-        depositoryContract: authorized.depository,
-        token: authorized.token,
-        amountInBaseUnits: authorized.amount,
-        encodedArgs: authorized.encodedArgs,
-        swapSequenceNumber: authorized.depositId,
-    }), /must not contain authorization entries/)
+    t.mock.method(Horizon.Server.prototype, 'fetchBaseFee', async () => 100)
+    t.mock.method(rpc.Server.prototype, 'prepareTransaction', async transaction => {
+        calls.push('prepare')
+        const operation = transaction.operations[0]
+        assert.equal(transaction.source, sourceKey.publicKey())
+        assert.equal(transaction.sequence, (BigInt(sourceSequence) + 1n).toString())
+        assert.equal(operation.source, sourceKey.publicKey())
+        assert.deepEqual(operation.auth, [])
+        assert.deepEqual(operation.func.invokeContract.args.map(arg => arg.toXdr('base64')),
+            fixture.transaction.operations[0].func.invokeContract.args.map(arg => arg.toXdr('base64')))
+        return fixture.transaction
+    })
+    t.mock.method(stellarKitManager, 'revalidate', async (address, passphrase) => {
+        calls.push('revalidate')
+        assert.equal(address, sourceKey.publicKey())
+        assert.equal(passphrase, fixture.networkPassphrase)
+    })
+    t.mock.method(stellarKitManager, 'signTransaction', async (envelope, passphrase, address) => {
+        calls.push('sign')
+        assert.equal(address, sourceKey.publicKey())
+        const transaction = TransactionBuilder.fromXdr(envelope, passphrase)
+        transaction.sign(sourceKey)
+        return { signedTxXdr: transaction.toXdr(), signerAddress: address }
+    })
+    t.mock.method(Horizon.Server.prototype, 'submitTransaction', async transaction => {
+        calls.push('submit')
+        assert.equal(transaction.signatures.length, 1)
+        return { successful: true, hash: 'deposit-hash' }
+    })
+    const params = {
+        selectedWallet: { address: sourceKey.publicKey() },
+        depositAddress: fixture.depository,
+        network: {
+            name: 'STELLAR_TESTNET',
+            type: 'stellar',
+            chain_id: fixture.networkPassphrase,
+            node_url: 'https://deposit-flow.example',
+        },
+        token: fixture.token,
+        amountInBaseUnits: fixture.amount,
+        encodedArgs: fixture.encodedArgs,
+        sequenceNumber: fixture.depositId,
+        callData: '',
+    }
+    const provider = createStellarTransfer()
+    assert.equal(await provider.executeTransfer(params), 'deposit-hash')
+    assert.deepEqual(calls, ['prepare', 'revalidate', 'sign', 'submit'])
+
+    calls.length = 0
+    const tampered = buildFixture({ receiver: Keypair.random().publicKey() })
+    t.mock.method(rpc.Server.prototype, 'prepareTransaction', async () => tampered.transaction)
+    await assert.rejects(provider.executeTransfer(params), /encoded_args do not match/)
+    assert.deepEqual(calls, [])
+})
+
+test('rejects malformed and mismatched deposit components before simulation', () => {
+    const fixture = buildFixture()
+    const withArg = (index, value) => ({ encodedArgs: fixture.encodedArgs.map((arg, i) => i === index ? value : arg) })
+    assert.throws(() => buildDepositOperation(fixture, { encodedArgs: [] }), /exactly four/)
+    assert.throws(() => buildDepositOperation(fixture, { encodedArgs: [sourceKey.publicKey(), ...fixture.encodedArgs] }), /exactly four/)
+    for (const id of ['2a', 'z'.repeat(64), `0x${fixture.encodedArgs[0]}`]) {
+        assert.throws(() => buildDepositOperation(fixture, withArg(0, id)), /32 hex-encoded bytes/)
+    }
+    assert.throws(() => buildDepositOperation(fixture, withArg(0, '0'.repeat(64))), /ID does not match/)
+    assert.throws(() => buildDepositOperation(fixture, withArg(1, sourceKey.publicKey())), /asset contract is invalid/)
+    assert.throws(() => buildDepositOperation(fixture, withArg(1, depositoryContract)), /asset does not match/)
+    assert.throws(() => buildDepositOperation(fixture, withArg(2, depositoryContract)), /receiver is invalid/)
+    for (const amount of ['0', '-1', '1.5', '1e7']) {
+        assert.throws(() => buildDepositOperation(fixture, withArg(3, amount)), /amount is invalid/)
+    }
+    assert.throws(() => buildDepositOperation(fixture, withArg(3, '1')), /amount does not match/)
+    assert.throws(() => buildDepositOperation(fixture, withArg(3, (1n << 127n).toString())))
+    assert.throws(() => buildDepositOperation(fixture, { selectedAddress: depositoryContract }), /source account is invalid/)
+    assert.throws(() => buildDepositOperation(fixture, { depositoryContract: sourceKey.publicKey() }), /must be a C-address/)
 })
 
 test('rejects security-sensitive depository XDR mismatches', () => {
@@ -316,7 +377,7 @@ test('rejects security-sensitive depository XDR mismatches', () => {
     assert.throws(() => validateFixture(fixture, { token: issuedToken }), /asset does not match/)
     assert.throws(() => validateFixture(fixture, { swapSequenceNumber: 43 }), /ID does not match/)
     assert.throws(() => validateFixture(fixture, {
-        encodedArgs: fixture.encodedArgs.map((value, index) => index === 3 ? otherSource : value),
+        encodedArgs: fixture.encodedArgs.map((value, index) => index === 2 ? otherSource : value),
     }), /encoded_args do not match/)
     assert.throws(() => validateFixture(fixture, { currentAccountSequence: '12344' }), error => (
         error.name === 'TransactionExpired' && /stale account sequence/.test(error.message)


### PR DESCRIPTION
Stellar deposits fail when the API returns null `call_data` and omits `from_address`. Build `deposit(from, id, token, receiver, amount)` locally from the four `encoded_args`, using the connected wallet for both `from` and the operation source.

Companion to https://github.com/layerswap/monorepo/pull/4632. This expects that PR's four-argument response and should be coordinated with its rollout.

The adapter validates the deposit ID, token, receiver and amount before simulation, then preserves the existing prepared transaction, authorization tree and signed transaction checks. Includes a patch changeset for `@layerswap/wallet-stellar`.

Validation: built the Stellar adapter and its workspace dependencies; all 15 Stellar tests pass. Coverage includes native and issued assets, wallet switching, malformed inputs, prepare/sign/submit without API call data or source address, and rejecting a modified receiver before signing. RPC and wallet calls are mocked; no live transaction was submitted.
