### PR TITLE
BAB-338: Allow editing minimum receive for token swaps

### DIFF
--- a/packages/widget/core/package.json
+++ b/packages/widget/core/package.json
@@ -36,6 +36,7 @@
     "build:css": "postcss ./src/styles/globals.css -o dist/index.css --config postcss.config.js --env production",
     "build:esm+types": "tsc --project tsconfig.json --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types && tsc-alias -p tsconfig.json --outDir ./dist/esm && tsc-alias -p tsconfig.json --outDir ./dist/types",
     "check:types": "tsc --noEmit",
+    "test": "node --test tests/*.test.mjs",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "tsc-watch -p tsconfig.json --outDir ./dist/esm --onSuccess \"tsc-alias -p tsconfig.json --outDir ./dist/esm\""
   },

--- a/packages/widget/core/src/components/Input/Amount/index.tsx
+++ b/packages/widget/core/src/components/Input/Amount/index.tsx
@@ -9,6 +9,8 @@ import { resolveTokenUsdPrice } from "@/helpers/tokenHelper";
 import { SwapFormValues } from "@/components/Pages/Swap/Form/SwapFormValues";
 import { useUsdTokenSync } from "@/hooks/useUsdTokenSync";
 import { ArrowUpDown } from "lucide-react";
+import { useSlippageStore } from '@/stores/slippageStore';
+import { formReceiveSettingsScope } from '@/lib/receiveSettings';
 
 interface AmountFieldProps {
     fee: ReturnType<typeof useQuoteData>['quote'];
@@ -26,6 +28,8 @@ const AmountField = forwardRef(function AmountField({ actionValue, actionValueUs
     const name = "amount"
     const amountRef = useRef(ref)
     const suffixRef = useRef<HTMLDivElement>(null);
+    const receiveScope = formReceiveSettingsScope(values);
+    const preserveTokenAmount = useSlippageStore(state => state.receiveSettings.mode === 'minimum' && state.receiveSettings.scope === receiveScope);
 
     const {
         sourceCurrencyPriceInUsd,
@@ -38,6 +42,7 @@ const AmountField = forwardRef(function AmountField({ actionValue, actionValueUs
         fromCurrency,
         amount,
         setFieldValue,
+        preserveTokenAmount,
     });
 
     // --- Token mode display computations ---

--- a/packages/widget/core/src/components/Input/DestinationPicker.tsx
+++ b/packages/widget/core/src/components/Input/DestinationPicker.tsx
@@ -5,9 +5,7 @@ import DestinationWalletPicker from "./DestinationWalletPicker";
 import { useFormikContext } from "formik";
 import { Partner } from "../../Models/Partner";
 import { ReceiveAmount } from "./Amount/ReceiveAmount";
-import { transformFormValuesToQuoteArgs, useQuoteData } from "@/hooks/useFee";
-import { useMemo } from "react";
-import { useSwapDataState } from "@/context/swap";
+import type { useQuoteData } from "@/hooks/useFee";
 import { SwapFormValues } from "../Pages/Swap/Form/SwapFormValues";
 
 type Props = {
@@ -17,13 +15,9 @@ type Props = {
 }
 
 const DestinationPicker = (props: Props) => {
-    const { partner } = props
+    const { partner, fee, isFeeLoading } = props
     const { values } = useFormikContext<SwapFormValues>()
     const { toAsset: toCurrency } = values
-    const quoteArgs = useMemo(() => transformFormValuesToQuoteArgs(values), [values]);
-    const { swapId } = useSwapDataState()
-    const quoteRefreshInterval = !!swapId ? 0 : undefined;
-    const { quote, isQuoteLoading } = useQuoteData(quoteArgs, { refreshInterval: quoteRefreshInterval });
 
     return <div className="flex flex-col w-full bg-secondary-500 rounded-2xl p-4 pb-3.75 space-y-6.75">
         <div className="grid grid-cols-9 gap-2 items-center h-7">
@@ -42,8 +36,8 @@ const DestinationPicker = (props: Props) => {
                 <div className="min-w-0 overflow-hidden">
                     <ReceiveAmount
                         destination_token={toCurrency}
-                        fee={quote}
-                        isFeeLoading={isQuoteLoading}
+                        fee={fee}
+                        isFeeLoading={isFeeLoading}
                     />
                 </div>
                 <div className="justify-self-end self-start">

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/Slippage.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/Slippage.tsx
@@ -1,242 +1,196 @@
 import { SwapQuote } from "@/lib/apiClients/layerSwapApiClient"
 import { SwapValues } from "."
 import { Info, Pencil } from "lucide-react"
-import { useCallback, useEffect, useRef, useState, forwardRef } from "react"
+import { useEffect, useId, useRef, useState } from "react"
 import { useClickOutside } from "@/hooks/useClickOutside"
 import clsx from "clsx"
 import { useSlippageStore } from "@/stores/slippageStore"
-import { Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/tooltip"
+import { formReceiveSettingsScope, isTokenSwap, quotedMinimumInput, receiveSettingsError, resolveReceiveSettings } from "@/lib/receiveSettings"
+import type { QuoteError } from "@/hooks/useFee"
 
 type SlippageProps = {
     quoteData: SwapQuote | undefined
     values: SwapValues
     disableEditingBackground?: boolean
+    allowMinimumReceive?: boolean
+    quoteError?: QuoteError
+    isQuoteLoading?: boolean
 }
-const HIGH_SLIPPAGE_THRESHOLD_PERCENT = 4.2;
+const HIGH_SLIPPAGE_THRESHOLD_PERCENT = 4.2
 
-export const Slippage = ({ quoteData, values, disableEditingBackground }: SlippageProps) => {
+export const Slippage = ({ quoteData, values, disableEditingBackground, allowMinimumReceive, quoteError, isQuoteLoading }: SlippageProps) => {
     const [editingSlippage, setEditingSlippage] = useState(false)
-    const { ref, isActive, activate } = useClickOutside<HTMLDivElement>()
-    const { slippage, setSlippage, autoSlippage, setAutoSlippage } = useSlippageStore()
-    const inputRef = useRef<HTMLInputElement | null>(null)
+    const [editingMinimum, setEditingMinimum] = useState(false)
     const [editingCustomSlippage, setEditingCustomSlippage] = useState(false)
+    const [slippageDraft, setSlippageDraft] = useState('')
+    const { ref, isActive, activate } = useClickOutside<HTMLDivElement>()
+    const storedSettings = useSlippageStore(state => state.receiveSettings)
+    const setReceiveSettings = useSlippageStore(state => state.setReceiveSettings)
+    const clearSlippage = useSlippageStore(state => state.clearSlippage)
+    const scope = formReceiveSettingsScope(values)
+    const settings = resolveReceiveSettings(storedSettings, scope, isTokenSwap(values.fromAsset?.symbol, values.toAsset?.symbol))
+    const inputRef = useRef<HTMLInputElement>(null)
+    const minimumInputRef = useRef<HTMLInputElement>(null)
+    const id = useId()
 
-    const currentSlippagePercent = ((slippage ?? quoteData?.slippage) ?? 0) * 100
-    const isHighSlippage = currentSlippagePercent > HIGH_SLIPPAGE_THRESHOLD_PERCENT
+    const autoSlippage = settings.mode === 'auto'
+    const currentSlippagePercent = settings.mode === 'slippage' ? Number(settings.percent) : quoteData?.slippage === undefined ? undefined : quoteData.slippage * 100
+    const slippageText = currentSlippagePercent !== undefined && Number.isFinite(currentSlippagePercent) ? currentSlippagePercent.toFixed(2) : '—'
+    const isHighSlippage = currentSlippagePercent !== undefined && currentSlippagePercent > HIGH_SLIPPAGE_THRESHOLD_PERCENT
+    const minimum = settings.mode === 'minimum' ? settings.amount : quotedMinimumInput(quoteData?.min_receive_amount)
+    const validationError = receiveSettingsError(settings)
+    const requestError = quoteError?.response?.data?.error?.message || quoteError?.message
+    const error = validationError || (!isQuoteLoading && requestError)
+    const token = values.toAsset?.asset
 
     useEffect(() => {
-        if (!isActive && editingSlippage) {
+        if (!isActive) {
             setEditingSlippage(false)
+            setEditingMinimum(false)
             setEditingCustomSlippage(false)
         }
-    }, [isActive, editingSlippage])
+    }, [isActive])
 
-    const handleAutoButtonClick = useCallback(() => {
-        if (autoSlippage) {
-            setEditingCustomSlippage(true)
-            setTimeout(() => inputRef.current?.focus(), 0)
-        }
-        else {
-            setEditingCustomSlippage(false)
-        }
-        setSlippage(undefined)
-        setAutoSlippage(!autoSlippage)
-    }, [autoSlippage, setAutoSlippage, setEditingCustomSlippage, setSlippage])
+    useEffect(() => {
+        if (editingMinimum) minimumInputRef.current?.focus()
+        else if (editingCustomSlippage) inputRef.current?.focus()
+    }, [editingMinimum, editingCustomSlippage])
+
+    const editSlippage = () => {
+        setSlippageDraft(String(currentSlippagePercent ?? 0.5))
+        setEditingMinimum(false)
+        setEditingCustomSlippage(true)
+    }
 
     return (
-        <div ref={ref} className={clsx("flex items-center w-full justify-between gap-1 text-sm py-1", disableEditingBackground ? "px-3" : "px-2", { "bg-secondary-700 rounded-xl": editingSlippage && !disableEditingBackground })}>
-            <div className="inline-flex items-center text-left py-2">
-                <label className="flex items-center gap-1">
+        <div ref={ref}>
+            {allowMinimumReceive && (
+                <div className={clsx("grid grid-cols-[auto_minmax(0,1fr)] items-center w-full gap-2 text-sm py-2", disableEditingBackground ? "px-3" : "px-2")}>
+                    <label htmlFor={`${id}-minimum`} className="text-secondary-text" title={`Minimum ${token} received after fees and refuel`}>Receive at least</label>
+                    {editingMinimum ? (
+                        <div className="flex items-center justify-self-end gap-2 min-w-0 max-w-full rounded-lg border border-secondary-300 px-2 h-7 focus-within:border-primary-text">
+                            <input
+                                id={`${id}-minimum`}
+                                ref={minimumInputRef}
+                                type="text"
+                                inputMode="decimal"
+                                autoComplete="off"
+                                aria-label={`Minimum receive in ${token}`}
+                                aria-invalid={!!error}
+                                aria-describedby={`${id}-minimum-hint${error ? ` ${id}-error` : ''}`}
+                                className="w-40 min-w-0 bg-transparent border-none outline-none text-base text-right text-primary-text p-0"
+                                value={minimum}
+                                onChange={e => setReceiveSettings({ mode: 'minimum', amount: e.target.value, scope, precision: values.toAsset?.precision ?? values.toAsset?.decimals ?? 0 })}
+                                onKeyDown={e => { if (e.key === 'Enter') e.preventDefault() }}
+                            />
+                            <span className="text-secondary-text shrink-0">{token}</span>
+                        </div>
+                    ) : (
+                        <button
+                            type="button"
+                            aria-label="Edit minimum receive"
+                            data-attr="edit-min-receive"
+                            onClick={() => {
+                                setEditingMinimum(true)
+                                setEditingCustomSlippage(false)
+                                activate()
+                            }}
+                            className="flex items-center justify-self-end gap-1 h-7 text-primary-text min-w-0 max-w-full rounded-md focus-visible:outline focus-visible:outline-2"
+                        >
+                            <span className="truncate text-right" title={`${minimum || '—'} ${token}`}>{minimum || '—'} {token}</span>
+                            <span className="shrink-0 hover:bg-secondary-400 p-1 bg-secondary-300 rounded-md text-secondary-text"><Pencil className="h-3 w-3" /></span>
+                        </button>
+                    )}
+                    <span id={`${id}-minimum-hint`} className="sr-only">Minimum {token} received after fees and refuel. Your send amount stays the same.</span>
+                </div>
+            )}
+            <div className={clsx("flex flex-wrap items-center w-full justify-between gap-1 text-sm py-1", disableEditingBackground ? "px-3" : "px-2", { "bg-secondary-700 rounded-xl": editingSlippage && !disableEditingBackground })}>
+                <div className="inline-flex items-center text-left py-2 gap-1">
                     <span className={clsx(isHighSlippage ? "text-warning-foreground" : "text-secondary-text")}>
-                        {editingSlippage ? (isHighSlippage ? "High" : "Slippage") : (isHighSlippage ? "High slippage" : "Slippage")}
+                        {isHighSlippage ? "High slippage" : "Slippage"}
                     </span>
                     <Tooltip openOnClick>
                         <TooltipTrigger asChild>
-                            <span>
-                                <Info className={clsx('w-4 h-4', isHighSlippage ? "text-warning-foreground" : "text-secondary-text")} />
-                            </span>
+                            <button type="button" aria-label="About slippage" className="text-secondary-text rounded-sm focus-visible:outline focus-visible:outline-2">
+                                <Info className={clsx('w-4 h-4', isHighSlippage && "text-warning-foreground")} />
+                            </button>
                         </TooltipTrigger>
                         <TooltipContent className="pointer-events-none w-80 grow p-2 border-none! bg-secondary-300! text-xs rounded-xl" side="top" align="start" alignOffset={-30}>
                             <p>{isHighSlippage ? "High slippage increases the risk of receiving significantly less than the quoted amount." : "Your transaction will be refunded if the price moves more than the slippage percentage."}</p>
                         </TooltipContent>
                     </Tooltip>
-                </label>
-            </div>
-            {
-                !editingSlippage &&
-                <div className="text-right flex items-center gap-1">
-                    {!slippage && <div className="text-secondary-text">(Auto)</div>}
-                    <span className={clsx(isHighSlippage ? "text-warning-foreground" : "text-primary-text")}>
-                        {currentSlippagePercent.toFixed(2)}%
-                    </span>
-                    <div
-                        data-attr="edit-slippage"
-                        onClick={() => { setEditingSlippage(true); activate() }}
-                        className="cursor-pointer hover:bg-secondary-400 p-1 bg-secondary-300 rounded-md text-secondary-text">
-                        <Pencil className="h-3 w-3" />
-                    </div>
                 </div>
-            }
-            {
-                editingSlippage &&
-                <div className="flex items-center gap-1">
-                    {
-                        !autoSlippage && <span className="flex items-center gap-1 max-sm:hidden">
-                            <QuickAction value={0.5} />
-                            <QuickAction value={1} />
-                            <QuickAction value={2.5} />
-                        </span>
-                    }
-
-                    {!editingCustomSlippage &&
-                        <div
-                            className={clsx("flex items-center gap-1 text-sm px-2 h-8 border border-secondary-300 rounded-lg font-normal leading-4 cursor-pointer", isHighSlippage && "shadow-[inset_0_0_0_1px] shadow-warning-foreground")}
+                {!editingSlippage ? (
+                    <div className="text-right flex items-center gap-1 h-8">
+                        {autoSlippage && <span className="text-secondary-text">(Auto)</span>}
+                        <span className={clsx(isHighSlippage ? "text-warning-foreground" : "text-primary-text")}>{slippageText}%</span>
+                        <button
+                            type="button"
+                            aria-label="Edit slippage"
+                            data-attr="edit-slippage"
+                            onClick={() => { setEditingSlippage(true); activate() }}
+                            className="cursor-pointer hover:bg-secondary-400 p-1 bg-secondary-300 rounded-md text-secondary-text focus-visible:outline focus-visible:outline-2">
+                            <Pencil className="h-3 w-3" />
+                        </button>
+                        {settings.mode === 'minimum' && <button type="button" onClick={clearSlippage} className="rounded-lg px-3 h-8 bg-secondary-500 border border-secondary-300 text-primary-text">Auto</button>}
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-1">
+                        {!autoSlippage && <span className="flex items-center gap-1 max-sm:hidden">
+                            {[0.5, 1, 2.5].map(value => <QuickAction key={value} value={value} onClick={() => { setReceiveSettings({ mode: 'slippage', percent: String(value) }); setEditingMinimum(false) }} />)}
+                        </span>}
+                        {editingCustomSlippage ? (
+                            <div className={clsx("flex items-center gap-1 text-sm px-2 h-8 w-20 border border-secondary-300 rounded-lg font-normal leading-4 focus-within:border-primary-text", isHighSlippage && "shadow-[inset_0_0_0_1px] shadow-warning-foreground")}>
+                                <input
+                                    ref={inputRef}
+                                    type="text"
+                                    inputMode="decimal"
+                                    autoComplete="off"
+                                    aria-label="Slippage percentage"
+                                    aria-invalid={settings.mode === 'slippage' && !!validationError}
+                                    aria-describedby={error ? `${id}-error` : undefined}
+                                    className="w-full bg-transparent border-none outline-none text-base p-0 text-right text-primary-text"
+                                    value={settings.mode === 'slippage' ? settings.percent : slippageDraft}
+                                    onChange={e => setReceiveSettings({ mode: 'slippage', percent: e.target.value })}
+                                    onKeyDown={e => { if (e.key === 'Enter') e.preventDefault() }}
+                                />
+                                <span className="text-secondary-text">%</span>
+                            </div>
+                        ) : (
+                            <button type="button" aria-label="Enter slippage percentage" className="flex items-center gap-1 text-sm px-2 h-8 border border-secondary-300 rounded-lg font-normal leading-4" onClick={editSlippage}>
+                                <span className={clsx(isHighSlippage ? "text-warning-foreground" : "text-primary-text")}>{slippageText}</span>
+                                <span className="text-secondary-text">%</span>
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            aria-pressed={autoSlippage}
                             onClick={() => {
-                                if (!slippage && quoteData?.slippage) {
-                                    setSlippage(quoteData.slippage);
-                                }
-                                setEditingCustomSlippage(true);
-                                setTimeout(() => inputRef.current?.focus(), 0)
-                                setAutoSlippage(false)
-                            }}>
-                            <span className={clsx(isHighSlippage ? "text-warning-foreground" : "text-primary-text")}>
-                                {currentSlippagePercent.toFixed(2)}
-                            </span>
-                            <span className="text-secondary-text">
-                                %
-                            </span>
-                        </div>
-                    }
-                    {
-                        editingCustomSlippage &&
-                        <SlippageInput
-                            ref={inputRef}
-                            valueDecimal={slippage}
-                            onEditing={() => setAutoSlippage(false)}
-                            onDebouncedChange={(decimal) => setSlippage(decimal)}
-                        />
-                    }
-                    <div
-                        onClick={handleAutoButtonClick}
-                        className={clsx(
-                            "rounded-lg px-3 h-8 flex items-center font-medium leading-4 cursor-pointer border transition-colors duration-300",
-                            autoSlippage ? "bg-secondary-300 border-secondary-100" : "bg-secondary-500 border-transparent",
-                        )}>
-                        Auto
+                                if (autoSlippage) editSlippage()
+                                else { clearSlippage(); setEditingMinimum(false); setEditingCustomSlippage(false) }
+                            }}
+                            className={clsx("rounded-lg px-3 h-8 flex items-center font-medium leading-4 border transition-colors duration-300", autoSlippage ? "bg-secondary-300 border-secondary-100" : "bg-secondary-500 border-transparent")}
+                        >Auto</button>
                     </div>
-                </div>
-
-            }
-
+                )}
+            </div>
+            {error && <p id={`${id}-error`} role="alert" className="px-2 py-2 text-xs text-warning-foreground">{error} Edit the value or return to Auto.</p>}
+            {!error && !quoteData && !isQuoteLoading && allowMinimumReceive && <p role="status" className="px-2 py-2 text-xs text-secondary-text">No quote available. Edit the minimum receive or slippage, or return to Auto.</p>}
         </div>
     )
 }
-type QuickActionProps = {
-    value: number
-    className?: string
-}
-const QuickAction = ({ value, className }: QuickActionProps) => {
-    const { setSlippage } = useSlippageStore()
-    const [flash, setFlash] = useState(false)
 
+const QuickAction = ({ value, onClick }: { value: number; onClick: () => void }) => {
+    const [flash, setFlash] = useState(false)
+    useEffect(() => {
+        if (!flash) return
+        const timeout = setTimeout(() => setFlash(false), 600)
+        return () => clearTimeout(timeout)
+    }, [flash])
     return (
-        <button
-            type="button"
-            onClick={() => {
-                setSlippage(value / 100)
-                setFlash(true)
-                setTimeout(() => setFlash(false), 600)
-            }}
-            className={clsx(
-                "flex items-center text-secondary-text px-2 py-1 border text-xs rounded-lg font-normal leading-4 cursor-pointer transition-colors ease-in-out duration-200",
-                flash ? "bg-secondary-300" : "bg-secondary-500"
-            )}>
-            <span>{value.toFixed(2)}</span>
-            <span>%</span>
+        <button type="button" onClick={() => { onClick(); setFlash(true) }} className={clsx("flex items-center text-secondary-text px-2 py-1 border text-xs rounded-lg font-normal leading-4 cursor-pointer transition-colors ease-in-out duration-200", flash ? "bg-secondary-300" : "bg-secondary-500")}>
+            <span>{value.toFixed(2)}</span><span>%</span>
         </button>
     )
 }
-
-type SlippageInputProps = {
-    valueDecimal: number | undefined
-    onDebouncedChange: (decimal: number | undefined) => void
-    onEditing?: () => void
-}
-
-const SlippageInput = forwardRef<HTMLInputElement, SlippageInputProps>(function SlippageInput({ valueDecimal, onDebouncedChange, onEditing }, ref) {
-    const [localPercent, setLocalPercent] = useState<number | undefined>(valueDecimal !== undefined ? valueDecimal * 100 : undefined)
-    const [previousValidValue, setPreviousValidValue] = useState<number | undefined>(valueDecimal !== undefined ? valueDecimal * 100 : undefined)
-
-    useEffect(() => {
-        const newPercent = valueDecimal !== undefined ? Math.round(valueDecimal * 10000) / 100 : undefined
-        setLocalPercent(newPercent)
-        if (newPercent !== undefined && newPercent >= 0.1 && newPercent <= 5) {
-            setPreviousValidValue(newPercent)
-        }
-    }, [valueDecimal])
-
-    const invalid = localPercent !== undefined && (localPercent < 0.1 || localPercent > 5)
-    const isHighSlippage = localPercent !== undefined && localPercent > HIGH_SLIPPAGE_THRESHOLD_PERCENT
-
-    useEffect(() => {
-        const t = setTimeout(() => {
-            if (invalid) return
-            if (localPercent !== undefined && localPercent >= 0.1 && localPercent <= 5) setPreviousValidValue(localPercent)
-            onDebouncedChange(localPercent !== undefined ? Math.round(localPercent * 100) / 10000 : undefined)
-        }, 300)
-        return () => clearTimeout(t)
-    }, [localPercent, invalid, onDebouncedChange])
-
-    return (
-        <div className="relative">
-            <Popover open={invalid}>
-                <PopoverTrigger asChild>
-                    <div
-                        className={clsx(
-                            "flex items-center gap-1 text-sm px-2 h-8 w-16 border border-secondary-300 rounded-lg font-normal leading-4 focus-within:outline-none focus-within:ring-0",
-                            invalid && "animate-shake",
-                            isHighSlippage && "shadow-[inset_0_0_0_1px] shadow-warning-foreground"
-                        )}
-                    >
-                        <input
-                            type="number"
-                            ref={ref}
-                            autoComplete="off"
-                            autoFocus={false}
-                            title=""
-                            className={clsx("w-8 bg-transparent border-none outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 focus:border-transparent focus:shadow-none text-base leading-3.5 p-0 text-right",
-                                isHighSlippage ? "text-warning-foreground" : "text-primary-text"
-                            )}
-                            value={localPercent ?? ""}
-                            onChange={(e) => {
-                                const next = e.target.value === "" ? undefined : Number(e.target.value)
-                                if (!Number.isNaN(next as number)) {
-                                    onEditing?.()
-                                    setLocalPercent(next)
-                                }
-                            }}
-                            onBlur={() => {
-                                if (localPercent === undefined || localPercent === 0 || invalid) {
-                                    setLocalPercent(previousValidValue)
-                                    if (previousValidValue !== undefined) {
-                                        onDebouncedChange(Math.round(previousValidValue * 100) / 10000)
-                                    }
-                                }
-                            }}
-                            onKeyDown={(e) => {
-                                if (e.key == "Enter") {
-                                    e.preventDefault();
-                                    return false;
-                                }
-                            }}
-                        />
-                        <span className="text-secondary-text">%</span>
-                    </div>
-                </PopoverTrigger>
-                <PopoverContent side="top" align="center" className="text-xs">
-                    Slippage can not be out of 0.1% - 5% range.
-                </PopoverContent>
-            </Popover>
-        </div >
-    )
-})

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/SwapQuote/DetailedEstimates.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/SwapQuote/DetailedEstimates.tsx
@@ -19,19 +19,27 @@ import { useGaslessPreferenceStore } from "@/stores/gaslessPreferenceStore";
 import { isGaslessCapableRoute } from "@/helpers/gasless";
 import GaslessBadge from "../GaslessBadge";
 import ToggleButton from "@/components/Buttons/toggleButton";
+import type { QuoteError } from '@/hooks/useFee';
+import { isTokenSwap, quotedMinimumInput } from '@/lib/receiveSettings';
 
 type DetailedEstimatesProps = {
     quote: SwapQuote | undefined,
     reward?: QuoteReward,
     swapValues: SwapValues
     variant?: "base" | "extended"
+    allowMinimumReceive?: boolean
+    quoteError?: QuoteError
+    isQuoteLoading?: boolean
 }
 
 export const DetailedEstimates: FC<DetailedEstimatesProps> = ({
     quote,
     reward,
     swapValues: values,
-    variant
+    variant,
+    allowMinimumReceive,
+    quoteError,
+    isQuoteLoading,
 }) => {
     const shouldCheckNFT = reward?.campaign_type === "for_nft_holders" && reward?.nft_contract_address;
     const { balance: nftBalance, isLoading, error } = useSWRNftBalance(
@@ -46,7 +54,13 @@ export const DetailedEstimates: FC<DetailedEstimatesProps> = ({
         <Fees quote={quote} values={values} />
         {values.depositMethod !== "deposit_address" && <Rate fromAsset={values?.fromAsset} toAsset={values?.toAsset} rate={quote?.rate} />}
         {values.depositMethod === "deposit_address" && variant === "extended" && values?.fromAsset?.contract && <ExchangeTokenContract fromAsset={values?.fromAsset} network={values?.from} />}
-        {variant === "extended" && values.depositMethod === "wallet" && <Slippage quoteData={quote} values={values} />}
+        {variant === "extended" && values.depositMethod === "wallet" && (
+            isTokenSwap(values.fromAsset?.symbol, values.toAsset?.symbol)
+                ? <Slippage quoteData={quote} values={values} allowMinimumReceive={allowMinimumReceive} quoteError={quoteError} isQuoteLoading={isQuoteLoading} />
+                : allowMinimumReceive && quote && <RowWrapper title="Receive at least">
+                    <span>{quotedMinimumInput(quote.min_receive_amount) || '—'} {values.toAsset?.asset}</span>
+                </RowWrapper>
+        )}
         <Estimates quote={quote} />
         {showReward && <Reward reward={reward} />}
     </div>

--- a/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/index.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/FeeDetails/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/shadcn/accordion';
 import clsx from 'clsx';
 import { ChevronDown } from 'lucide-react';
@@ -28,6 +28,8 @@ import AverageCompletionTime from '@/components/Common/AverageCompletionTime';
 import { useGaslessPreferenceStore } from '@/stores/gaslessPreferenceStore';
 import { isGaslessCapableRoute } from '@/helpers/gasless';
 import GaslessBadge from './GaslessBadge';
+import type { QuoteError } from '@/hooks/useFee';
+import { isTokenSwap } from '@/lib/receiveSettings';
 
 export interface SwapValues extends Omit<SwapFormValues, 'from' | 'to'> {
     from?: Network;
@@ -43,17 +45,26 @@ export interface QuoteComponentProps {
     reward?: QuoteReward | undefined;
     variant?: 'extended' | 'base';
     triggerClassnames?: string
+    allowMinimumReceive?: boolean
+    quoteError?: QuoteError
 }
 
-export default function QuoteDetails({ swapValues: values, quote, isQuoteLoading, reward, variant = 'extended', triggerClassnames }: QuoteComponentProps) {
+export default function QuoteDetails({ swapValues: values, quote, isQuoteLoading, reward, variant = 'extended', triggerClassnames, allowMinimumReceive, quoteError }: QuoteComponentProps) {
     const { toAsset, fromAsset: fromCurrency, destination_address } = values || {};
     const [isAccordionOpen, setIsAccordionOpen] = useState<boolean>(false);
+    const canEditReceive = allowMinimumReceive && values.depositMethod === 'wallet' && isTokenSwap(fromCurrency?.symbol, toAsset?.symbol);
+    const showReceiveError = !!canEditReceive && !quote && (!!quoteError || !isQuoteLoading);
+    const isOpen = isAccordionOpen || showReceiveError;
+    useEffect(() => {
+        // Keep the editor mounted when recovering from an error starts a new quote.
+        if (showReceiveError) setIsAccordionOpen(true);
+    }, [showReceiveError]);
 
     return (
         <>
             {
-                quote &&
-                <Accordion type='single' collapsible className='w-full' value={isAccordionOpen ? 'quote' : ''} onValueChange={(value) => { setIsAccordionOpen(value === 'quote') }}>
+                (quote || canEditReceive) &&
+                <Accordion type='single' collapsible className='w-full' value={isOpen ? 'quote' : ''} onValueChange={(value) => { setIsAccordionOpen(value === 'quote') }}>
                     <AccordionItem value='quote' className='bg-secondary-500 rounded-2xl'>
                         <AccordionTrigger
                             data-attr="see-swap-details"
@@ -61,13 +72,13 @@ export default function QuoteDetails({ swapValues: values, quote, isQuoteLoading
                                 'p-3.5 pr-5 w-full rounded-2xl flex items-center justify-between transition-colors duration-200 hover:bg-secondary-400',
                                 triggerClassnames,
                                 {
-                                    'bg-secondary-500': !isAccordionOpen,
-                                    'bg-secondary-400': isAccordionOpen,
-                                    'animate-pulse-strong': isQuoteLoading && !isAccordionOpen
+                                    'bg-secondary-500': !isOpen,
+                                    'bg-secondary-400': isOpen,
+                                    'animate-pulse-strong': isQuoteLoading && !isOpen
                                 }
                             )}>
                             {
-                                (isAccordionOpen) ?
+                                (isOpen || !quote) ?
                                     <p className='text-sm'>
                                         Details
                                     </p>
@@ -78,12 +89,15 @@ export default function QuoteDetails({ swapValues: values, quote, isQuoteLoading
                         </AccordionTrigger>
                         <AccordionContent className='rounded-2xl'>
                             {
-                                (quote || isQuoteLoading) && fromCurrency && toAsset &&
+                                (quote || isQuoteLoading || canEditReceive) && fromCurrency && toAsset &&
                                 <DetailedEstimates
                                     swapValues={values}
                                     quote={quote}
                                     variant={variant}
                                     reward={reward}
+                                    allowMinimumReceive={allowMinimumReceive}
+                                    quoteError={quoteError}
+                                    isQuoteLoading={isQuoteLoading}
                                 />
                             }
                         </AccordionContent>

--- a/packages/widget/core/src/components/Pages/Swap/Form/NetworkForm.tsx
+++ b/packages/widget/core/src/components/Pages/Swap/Form/NetworkForm.tsx
@@ -24,7 +24,6 @@ import RefuelToggle from "./FeeDetails/Refuel";
 import RefuelModal from "./FeeDetails/RefuelModal";
 import { SwapFormValues } from "./SwapFormValues";
 import { useCallbacks } from "@/context/callbackProvider";
-import { Slippage } from "./FeeDetails/Slippage";
 
 type Props = {
     partner?: Partner;
@@ -51,11 +50,11 @@ const NetworkForm: FC<Props> = ({ partner }) => {
     const quoteArgs = useMemo(() => transformFormValuesToQuoteArgs(values), [values]);
     const { swapId } = useSwapDataState()
     const quoteRefreshInterval = !!swapId ? 0 : undefined;
-    const { minAllowedAmount, maxAllowedAmount, minAllowedAmountInUsd, maxAllowedAmountInUsd, isQuoteLoading, quote, quoteTokenPrices } = useQuoteData(quoteArgs, { refreshInterval: quoteRefreshInterval });
+    const { minAllowedAmount, maxAllowedAmount, minAllowedAmountInUsd, maxAllowedAmountInUsd, isQuoteLoading, quote, displayQuote, quoteTokenPrices, quoteError } = useQuoteData(quoteArgs, { refreshInterval: quoteRefreshInterval });
 
     const toAsset = values.toAsset;
     const fromAsset = values.fromAsset;
-    const { formValidation, autoSlippageWouldWork, isTestingAutoSlippage } = useValidationContext();
+    const { formValidation } = useValidationContext();
     const initialSettings = useInitialSettings();
 
     const isValid = !formValidation.message;
@@ -66,7 +65,6 @@ const NetworkForm: FC<Props> = ({ partner }) => {
     useEffect(() => {
         onFormChange(values);
     }, [values, onFormChange]);
-    const shouldShowSlippage = autoSlippageWouldWork && !isTestingAutoSlippage;
 
     useEffect(() => {
         if (!source || !toAsset || !toAsset.refuel) {
@@ -104,7 +102,7 @@ const NetworkForm: FC<Props> = ({ partner }) => {
                             {
                                 !(initialSettings?.hideTo && values?.to) && <DestinationPicker
                                     isFeeLoading={isQuoteLoading}
-                                    fee={quote}
+                                    fee={displayQuote}
                                     partner={partner}
                                 />
                             }
@@ -117,19 +115,8 @@ const NetworkForm: FC<Props> = ({ partner }) => {
                                     onButtonClick={() => setOpenRefuelModal(true)}
                                 />
                             }
-                            {
-                                shouldShowSlippage ? (
-                                    <div className="mt-2 bg-secondary-500 rounded-xl">
-                                        <Slippage quoteData={undefined} values={values} disableEditingBackground />
-                                    </div>
-                                ) : null
-                            }
                             <ValidationError />
-                            {
-                                !autoSlippageWouldWork ? (
-                                    <QuoteDetails swapValues={values} quote={quote?.quote} reward={quote?.reward} isQuoteLoading={isQuoteLoading} triggerClassnames="mt-2" />
-                                ) : null
-                            }
+                            <QuoteDetails swapValues={values} quote={displayQuote?.quote} reward={displayQuote?.reward} isQuoteLoading={isQuoteLoading} triggerClassnames="mt-2" allowMinimumReceive={!!values.amount} quoteError={quoteError} />
                         </div>
                     </div>
                 </Widget.Content>

--- a/packages/widget/core/src/context/swap.tsx
+++ b/packages/widget/core/src/context/swap.tsx
@@ -29,6 +29,7 @@ import { useExtendedRoutesStore } from '@/stores/extendedRoutesStore';
 import { isDepositAddressFlow, isDepositAddressSwap } from '@/helpers/swapFlow';
 import { resolveSwapPollingInterval, SWAP_POLL_DEDUPE_MS } from '@/lib/swapPollingPolicy';
 import { KnownInternalNames } from '@layerswap/utils';
+import { formReceiveSettingsScope, isTokenSwap, receiveRequestParams, resolveReceiveSettings } from '@/lib/receiveSettings';
 
 export const SwapDataStateContext = createContext<SwapContextData | null>(null);
 
@@ -281,7 +282,8 @@ export function SwapDataProvider({ children, initialSwapData }: { children: Reac
         const isContract = contractCheckResult?.sourceIsContract ?? false
         const sourceIsSupported = sourceWalletIsSupported && !isContract
 
-        const slippage = useSlippageStore.getState().slippage
+        const scope = formReceiveSettingsScope(values)
+        const receiveSettings = resolveReceiveSettings(useSlippageStore.getState().receiveSettings, scope, isTokenSwap(fromCurrency.symbol, toCurrency.symbol))
         const gaslessEnabled = useGaslessPreferenceStore.getState().gaslessEnabled
 
         const useGasless = isGaslessCapableRoute({
@@ -299,7 +301,6 @@ export function SwapDataProvider({ children, initialSwapData }: { children: Reac
             sourceAmount: amount,
             availableRoutes: sourceRoutes,
         })
-        const isExtendedBridge = !!extendedPlan
         const requiresDepository = from.name == KnownInternalNames.Networks.StellarTestnet || from.name == KnownInternalNames.Networks.StellarMainnet
 
         const data: CreateSwapParams = extendedPlan ? buildCreateSwapParamsForExtendedRoute({
@@ -327,8 +328,8 @@ export function SwapDataProvider({ children, initialSwapData }: { children: Reac
             ...((useGasless || requiresDepository) && { use_depository: true }),
         }
 
-        if (!isExtendedBridge && depositMethod === 'wallet' && slippage && slippage > 0 && slippage < 0.8) {
-            data.slippage = slippage.toString()
+        if (depositMethod === 'wallet') {
+            Object.assign(data, receiveRequestParams(receiveSettings))
         }
 
         const swapResponse = await layerswapApiClient.CreateSwapAsync(data).catch((e) => {

--- a/packages/widget/core/src/context/validationContext.tsx
+++ b/packages/widget/core/src/context/validationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useMemo, ReactNode } from 'react';
+import React, { createContext, useEffect, useMemo, ReactNode } from 'react';
 import { useFormikContext } from 'formik';
 import { useInitialSettings } from './settings';
 import { transformFormValuesToQuoteArgs, useQuoteData } from '@/hooks/useFee';
@@ -12,6 +12,7 @@ import { useAutoSlippageTest } from '@/hooks/useAutoSlippageTest';
 import { useUsdModeStore } from '@/stores/usdModeStore';
 import { isDepositAddressFlow } from '@/helpers/swapFlow';
 import useExchangeNetworks from '@/hooks/useExchangeNetworks';
+import { formReceiveSettingsScope, isTokenSwap } from '@/lib/receiveSettings';
 
 export interface ValidationDetails {
     title?: string;
@@ -43,6 +44,11 @@ const ValidationContext = createContext<ValidationContextType>(defaultContext);
 
 export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     const { values } = useFormikContext<SwapFormValues>();
+    const receiveScope = formReceiveSettingsScope(values);
+    // Only the active form owns resets; quote consumers also include submitted swaps.
+    useEffect(() => {
+        useSlippageStore.getState().resetMinimumForScope(receiveScope);
+    }, [receiveScope]);
     const initialSettings = useInitialSettings();
     const { sameAccountNetwork } = initialSettings
     const { swapId } = useSwapDataState()
@@ -57,7 +63,7 @@ export const ValidationProvider: React.FC<{ children: ReactNode }> = ({ children
 
     const { autoSlippage } = useSlippageStore();
     const quoteErrorCode = quoteError?.response?.data?.error?.code || quoteError?.code;
-    const shouldTestAutoSlippage = !autoSlippage && !quote && !!values.amount && Number(values.amount) > 0 && !!values.from && !!values.to && !quoteErrorCode && !(isQuoteLoading || isDebouncing);
+    const shouldTestAutoSlippage = isTokenSwap(values.fromAsset?.symbol, values.toAsset?.symbol) && !autoSlippage && !quote && !!values.amount && Number(values.amount) > 0 && !!values.from && !!values.to && !quoteErrorCode && !(isQuoteLoading || isDebouncing);
     const { autoSlippageWouldWork, isTestingAutoSlippage } = useAutoSlippageTest({ values, shouldTest: shouldTestAutoSlippage });
 
     const { networks: exchangeWithdrawalNetworks, isLoading: exchangeNetworksLoading, isValidating: exchangeNetworksValidating } = useExchangeNetworks({ fromExchange: values.fromExchange?.name, to: values.to?.name, toAsset: values.toAsset?.symbol });

--- a/packages/widget/core/src/hooks/useFee.tsx
+++ b/packages/widget/core/src/hooks/useFee.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import useSWR, { useSWRConfig } from 'swr'
+import useSWR, { unstable_serialize, useSWRConfig } from 'swr'
 import { Quote, SwapBasicData, SwapQuote } from '../lib/apiClients/layerSwapApiClient'
 import { ApiResponse } from '../Models/ApiResponse'
 import { create } from 'zustand';
@@ -17,6 +17,10 @@ import { useSelectedAccount } from '@/context/swapAccounts'
 import { useGaslessPreferenceStore } from '@/stores/gaslessPreferenceStore'
 import { isGaslessCapableRoute } from '@/helpers/gasless'
 import { Address } from '@/lib/address/Address';
+import { isTokenSwap, receiveRequestParams, receiveSettingsError, receiveSettingsScope, resolveReceiveSettings } from '@/lib/receiveSettings'
+
+import { buildQuoteUrl } from '@/lib/quoteRequest'
+export { buildQuoteUrl, type QuoteUrlArgs } from '@/lib/quoteRequest'
 
 const apiClient = new LayerswapApiClient()
 
@@ -28,6 +32,8 @@ type UseQuoteData = {
     minAllowedAmountInUsd?: number
     maxAllowedAmountInUsd?: number
     quote?: Quote
+    // Estimates may stay visible during an edit; only `quote` is valid for submission.
+    displayQuote?: Quote
     quoteTokenPrices?: QuoteTokenPrices
     quoteError?: QuoteError
     limitsError?: QuoteError
@@ -77,24 +83,26 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
     const { skipLimits, refreshInterval } = options
 
     const [debouncedAmount, setDebouncedAmount] = useState(amount)
-    const [isDebouncing, setIsDebouncing] = useState(false)
-    const { slippage } = useSlippageStore()
+    const storedReceiveSettings = useSlippageStore(state => state.receiveSettings)
+    const receiveSettingsRevision = useSlippageStore(state => state.revision)
+    const receiveSettings = resolveReceiveSettings(storedReceiveSettings, receiveSettingsScope(formValues ?? {}), isTokenSwap(fromCurrency, toCurrency))
+    const selectionKey = JSON.stringify(receiveSettings)
+    const [debouncedSelectionKey, setDebouncedSelectionKey] = useState(selectionKey)
+    const isDebouncing = amount !== debouncedAmount || selectionKey !== debouncedSelectionKey
+    const inputError = receiveSettingsError(receiveSettings)
+    const receiveParams = inputError ? {} : receiveRequestParams(receiveSettings)
     useEffect(() => {
-        if (amount === debouncedAmount) {
-            setIsDebouncing(false)
-            return;
-        }
+        if (!isDebouncing) return
 
-        setIsDebouncing(true)
         const handler = setTimeout(() => {
             setDebouncedAmount(amount)
-            setIsDebouncing(false)
+            setDebouncedSelectionKey(selectionKey)
         }, 300)
 
         return () => {
             clearTimeout(handler)
         }
-    }, [amount])
+    }, [amount, selectionKey, isDebouncing])
 
     const use_deposit_address = depositMethod === 'wallet' ? false : true
 
@@ -158,7 +166,7 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
     // Bridge mode fetches the backend quote for the truncated real amount (A - fee).
     const effectiveAmount = isBridge ? extendedPlan.realAmount : debouncedAmount
 
-    const quoteURL = (hasQuoteParams && !isDebouncing && (!isBridge || (effectiveAmount && isPositiveDecimal(effectiveAmount))))
+    const quoteURL = (hasQuoteParams && !isDebouncing && !inputError && (!isBridge || (effectiveAmount && isPositiveDecimal(effectiveAmount))))
         ? buildQuoteUrl({
             sourceNetwork: effectiveFrom!,
             sourceToken: effectiveFromToken!,
@@ -167,7 +175,8 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
             amount: effectiveAmount || 0,
             refuel: !!refuel,
             useDepositAddress: effectiveUseDepositAddress,
-            slippage,
+            slippage: receiveParams.slippage === undefined ? undefined : Number(receiveParams.slippage),
+            minReceiveAmount: receiveParams.min_receive_amount,
             useGasless,
             destinationAddress,
             sourceAddress,
@@ -176,17 +185,16 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
 
     const { cache } = useSWRConfig();
     const isQuoteLoading = useLoadingStore((state) => state.isLoading);
-    // Remember the last settled quote we emitted, so that while the next one loads we don't flash stale data after an empty state (e.g. a route that errored).
-    const lastSettledQuoteRef = useRef<Quote | undefined>(undefined)
+    const displayQuoteRef = useRef<{ scope: string; quote: Quote } | undefined>(undefined)
     //TODO: implement middleware that handles the delay logic
-    const quoteFetchWrapper = useCallback(async (url: string): Promise<ApiResponse<Quote>> => {
+    const quoteFetchWrapper = useCallback(async ([url, revision]: readonly [string, number]): Promise<ApiResponse<Quote>> => {
         const { setLoading, key, setKey } = useLoadingStore.getState()
         try {
             if (key !== url) {
                 setLoading(true)
             }
 
-            const previousData = cache.get(url)?.data as ApiResponse<Quote>
+            const previousData = cache.get(unstable_serialize([url, revision]))?.data as ApiResponse<Quote>
             const newData = await apiClient.fetcher(url) as ApiResponse<Quote>
             if (previousData?.data?.quote && isDiffByPercent(previousData?.data?.quote.receive_amount, newData.data?.quote.receive_amount, 2)) {
                 const { setLoading } = useLoadingStore.getState()
@@ -200,36 +208,48 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
             return newData
         }
         catch (error) {
-            if (error.response?.data?.error?.code === "VALIDATION_ERROR") {
-                useSlippageStore.getState().clearSlippage()
-            }
             setLoading(false)
             setKey(null)
             throw error
         }
     }, [cache])
 
-    const { data: quote, mutate: mutateFee, error: quoteError, isLoading: swrIsLoading } = useSWR<ApiResponse<Quote>>(quoteURL, quoteFetchWrapper, {
+    // Returning to Auto must not reuse a quote (and token prices) from before the
+    // user's edits. All consumers still share and refresh the current selection.
+    const quoteKey = quoteURL ? [quoteURL, receiveSettingsRevision] as const : null
+    const { data: quote, mutate: mutateFee, error: requestError, isLoading: swrIsLoading } = useSWR<ApiResponse<Quote>>(quoteKey, quoteFetchWrapper, {
         refreshInterval: (refreshInterval || refreshInterval == 0) ? refreshInterval : 42000,
         dedupingInterval: 5000,
         keepPreviousData: true,
     })
 
-    const quoteData = quote?.data
+    const quoteError = inputError ? { code: 'RECEIVE_SETTINGS_INVALID', message: inputError } : requestError ?? (!swrIsLoading && !isDebouncing ? quote?.error : undefined)
+    const quoteData = swrIsLoading ? undefined : quote?.data
     const hasValidAmount = !!debouncedAmount && isPositiveDecimal(String(debouncedAmount))
     const isTransitioning = swrIsLoading || isDebouncing
-    const resolvedQuote = (quoteError || !hasQuoteParams || !hasValidAmount) ? undefined : quoteData
-    if (!isTransitioning) lastSettledQuoteRef.current = resolvedQuote
-    const suppressStale = isTransitioning && lastSettledQuoteRef.current === undefined
+    const resolvedQuote = (quoteError || isDebouncing || !quoteURL || !hasQuoteParams || !hasValidAmount) ? undefined : quoteData
 
     // Re-denominate the backend quote so the source side reads as the extended route.
-    let finalQuote = suppressStale ? undefined : resolvedQuote
+    let finalQuote = resolvedQuote
     if (extendedMapping && hasValidAmount && debouncedAmount) {
         const sourceAmount = String(debouncedAmount)
         if (isBridge && finalQuote && extendedNetworkObj && extendedTokenObj) {
             finalQuote = transformQuoteForExtendedRoute(finalQuote, extendedMapping, extendedNetworkObj, extendedTokenObj, sourceAmount)
         }
     }
+
+    // Changing the receive setting must not animate estimates to zero while its
+    // quote loads. Never carry these estimates across an amount or route change,
+    // or reuse them to validate or create a swap.
+    const displayScope = JSON.stringify([
+        receiveSettingsScope(formValues ?? {}), refuel, destinationAddress,
+        sourceAddress, useGasless, effectiveFrom, effectiveFromToken,
+    ])
+    const previousDisplayQuote = displayQuoteRef.current
+    const displayQuote = finalQuote ?? (isTransitioning && !quoteError && previousDisplayQuote?.scope === displayScope ? previousDisplayQuote.quote : undefined)
+    useEffect(() => {
+        displayQuoteRef.current = displayQuote ? { scope: displayScope, quote: displayQuote } : undefined
+    }, [displayScope, displayQuote])
 
     let minAllowedAmount = amountRange?.data?.min_amount
     let maxAllowedAmount = amountRange?.data?.max_amount
@@ -249,11 +269,12 @@ export function useQuoteData(formValues: Props | undefined, options: Options = {
         minAllowedAmountInUsd,
         maxAllowedAmountInUsd,
         quote: finalQuote,
-        quoteTokenPrices: (finalQuote?.quote && !suppressStale) ? {
+        displayQuote,
+        quoteTokenPrices: finalQuote?.quote ? {
             source_token: finalQuote.quote.source_token,
             destination_token: finalQuote.quote.destination_token,
         } : undefined,
-        isQuoteLoading,
+        isQuoteLoading: isQuoteLoading || swrIsLoading || isDebouncing,
         isDebouncing,
         quoteError,
         limitsError,
@@ -293,63 +314,6 @@ export function transformSwapDataToQuoteArgs(swapData: SwapBasicData | undefined
     }
 }
 
-export type QuoteUrlArgs = {
-    sourceNetwork: string
-    sourceToken: string
-    destinationNetwork: string
-    destinationToken: string
-    amount: string | number
-    refuel: boolean
-    useDepositAddress: boolean
-    slippage?: number
-    useGasless?: boolean
-    destinationAddress?: string
-    sourceAddress?: string
-}
-
-export function buildQuoteUrl(args: QuoteUrlArgs): string {
-    const {
-        sourceNetwork,
-        sourceToken,
-        destinationNetwork,
-        destinationToken,
-        amount,
-        refuel,
-        useDepositAddress,
-        slippage,
-        useGasless,
-        destinationAddress,
-        sourceAddress,
-    } = args
-
-    const params = new URLSearchParams({
-        source_network: sourceNetwork,
-        source_token: sourceToken,
-        destination_network: destinationNetwork,
-        destination_token: destinationToken,
-        amount: String(amount),
-        refuel: String(!!refuel),
-        use_deposit_address: useDepositAddress ? 'true' : 'false',
-    })
-
-    if (slippage !== undefined) {
-        params.append('slippage', String(slippage))
-    }
-
-    if (useGasless) {
-        params.append('use_gasless', 'true')
-    }
-
-    if (destinationAddress) {
-        params.append('destination_address', destinationAddress)
-    }
-
-    if (sourceAddress) {
-        params.append('source_address', sourceAddress)
-    }
-
-    return `/quote?${params.toString()}`
-}
 
 export const getLimits = async (swapValues: LimitsQueryOptions) => {
     const { sourceToken, sourceNetwork, destinationNetwork, destinationToken, refuel, useDepositAddress, destinationAddress } = swapValues || {}

--- a/packages/widget/core/src/hooks/useFormValidation.ts
+++ b/packages/widget/core/src/hooks/useFormValidation.ts
@@ -104,6 +104,12 @@ export function resolveFormValidation({ values, maxAllowedAmount, minAllowedAmou
 
     const quoteErrorCode = quoteError?.response?.data?.error?.code || quoteError?.code;
     const quoteErrorMessage = quoteError?.response?.data?.error?.message || quoteError?.message;
+    if (quoteErrorCode === 'RECEIVE_SETTINGS_INVALID') {
+        return { message: 'Check receive settings', code: quoteErrorCode };
+    }
+    if (quoteErrorCode === 'VALIDATION_ERROR') {
+        return { message: 'Check swap settings', code: quoteErrorCode };
+    }
     if (quoteError && quoteErrorCode !== "QUOTE_REQUIRES_NO_DEPOSIT_ADDRESS") {
         if (quoteErrorCode === "PRICE_IMPACT_TOO_HIGH") {
             return { message: 'Price impact too high', code: FORM_VALIDATION_ERROR_CODES.PRICE_IMPACT_TOO_HIGH };

--- a/packages/widget/core/src/hooks/useRouteValidation.tsx
+++ b/packages/widget/core/src/hooks/useRouteValidation.tsx
@@ -26,7 +26,7 @@ export function useRouteValidation(quoteError?: QuoteError, hasQuote?: boolean, 
 
     if (!hasQuote && autoSlippageWouldWork) {
         validationDetails = { title: 'Route Unavailable', type: 'warning', icon: <RouteOff className={ICON_CLASSES_WARNING} /> };
-        validationMessage = `This might be because of high slippage, try switching the slippage percentage to "Auto"`;
+        validationMessage = 'No quote is available with these receive settings. Edit the value or return to Auto.';
     }
 
     if (((from?.name && from?.name.toLowerCase() === initialSettings.sameAccountNetwork?.toLowerCase()) || (to?.name && to?.name.toLowerCase() === initialSettings.sameAccountNetwork?.toLowerCase()))) {

--- a/packages/widget/core/src/hooks/useUsdTokenSync.ts
+++ b/packages/widget/core/src/hooks/useUsdTokenSync.ts
@@ -23,6 +23,7 @@ interface UseUsdTokenSyncArgs {
     fromCurrency: { symbol?: string; precision?: number; price_in_usd?: number } | undefined;
     amount: string | undefined;
     setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
+    preserveTokenAmount?: boolean;
 }
 
 interface UseUsdTokenSyncReturn {
@@ -39,6 +40,7 @@ export function useUsdTokenSync({
     fromCurrency,
     amount,
     setFieldValue,
+    preserveTokenAmount = false,
 }: UseUsdTokenSyncArgs): UseUsdTokenSyncReturn {
     const isUsdMode = useUsdModeStore(s => s.isUsdMode);
     const usdAmount = useUsdModeStore(s => s.usdAmount);
@@ -116,8 +118,15 @@ export function useUsdTokenSync({
         }
         if (prevPriceRef.current === sourceCurrencyPriceInUsd) return;
         prevPriceRef.current = sourceCurrencyPriceInUsd;
+        if (preserveTokenAmount) {
+            // A fixed receive minimum belongs to this token send amount. Refresh
+            // its USD display instead of changing the amount and clearing the floor.
+            preciseUsdRef.current = Number(currentAmountRef.current || 0) * sourceCurrencyPriceInUsd;
+            setUsdAmount(preciseUsdRef.current.toFixed(2).replace(/\.?0+$/, ''));
+            return;
+        }
         computeAndSetTokenAmount(preciseUsdRef.current);
-    }, [sourceCurrencyPriceInUsd, isUsdMode, usdAmount, computeAndSetTokenAmount]);
+    }, [sourceCurrencyPriceInUsd, isUsdMode, usdAmount, computeAndSetTokenAmount, preserveTokenAmount, setUsdAmount]);
 
     // Recompute token amount when source token changes in USD mode
     useEffect(() => {

--- a/packages/widget/core/src/lib/apiClients/layerSwapApiClient.ts
+++ b/packages/widget/core/src/lib/apiClients/layerSwapApiClient.ts
@@ -145,6 +145,7 @@ export type CreateSwapParams = {
     destination_token: string
     refuel?: boolean,
     slippage?: string,
+    min_receive_amount?: string,
     destination_address: string,
     source_address?: string
     refund_address?: string

--- a/packages/widget/core/src/lib/quoteRequest.ts
+++ b/packages/widget/core/src/lib/quoteRequest.ts
@@ -1,0 +1,61 @@
+export type QuoteUrlArgs = {
+    sourceNetwork: string
+    sourceToken: string
+    destinationNetwork: string
+    destinationToken: string
+    amount: string | number
+    refuel: boolean
+    useDepositAddress: boolean
+    slippage?: number
+    minReceiveAmount?: string
+    useGasless?: boolean
+    destinationAddress?: string
+    sourceAddress?: string
+}
+
+export function buildQuoteUrl(args: QuoteUrlArgs): string {
+    const {
+        sourceNetwork,
+        sourceToken,
+        destinationNetwork,
+        destinationToken,
+        amount,
+        refuel,
+        useDepositAddress,
+        slippage,
+        minReceiveAmount,
+        useGasless,
+        destinationAddress,
+        sourceAddress,
+    } = args
+
+    const params = new URLSearchParams({
+        source_network: sourceNetwork,
+        source_token: sourceToken,
+        destination_network: destinationNetwork,
+        destination_token: destinationToken,
+        amount: String(amount),
+        refuel: String(!!refuel),
+        use_deposit_address: useDepositAddress ? 'true' : 'false',
+    })
+
+    if (minReceiveAmount !== undefined) {
+        params.append('min_receive_amount', minReceiveAmount)
+    } else if (slippage !== undefined) {
+        params.append('slippage', String(slippage))
+    }
+
+    if (useGasless) {
+        params.append('use_gasless', 'true')
+    }
+
+    if (destinationAddress) {
+        params.append('destination_address', destinationAddress)
+    }
+
+    if (sourceAddress) {
+        params.append('source_address', sourceAddress)
+    }
+
+    return `/quote?${params.toString()}`
+}

--- a/packages/widget/core/src/lib/receiveSettings.ts
+++ b/packages/widget/core/src/lib/receiveSettings.ts
@@ -1,0 +1,99 @@
+export type ReceiveSettings =
+    | { mode: 'auto' }
+    | { mode: 'slippage'; percent: string }
+    | { mode: 'minimum'; amount: string; scope: string; precision: number }
+
+export const AUTO_RECEIVE_SETTINGS: ReceiveSettings = { mode: 'auto' }
+
+type ReceiveScope = {
+    amount?: string | number
+    from?: string
+    fromCurrency?: string
+    to?: string
+    toCurrency?: string
+    depositMethod?: string
+}
+
+// Compare decimal amounts without converting them to floating point numbers.
+export function receiveSettingsScope({ amount, from, fromCurrency, to, toCurrency, depositMethod }: ReceiveScope): string {
+    const rawAmount = typeof amount === 'number' ? quotedMinimumInput(amount) : amount ?? ''
+    const normalizedAmount = rawAmount.replace(/^\./, '0.').replace(/^0+(?=\d)/, '').replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '')
+    return JSON.stringify([from, fromCurrency, to, toCurrency, normalizedAmount, depositMethod])
+}
+
+export function formReceiveSettingsScope(values: {
+    amount?: string | number
+    from?: { name: string }
+    fromAsset?: { symbol: string }
+    to?: { name: string }
+    toAsset?: { symbol: string }
+    depositMethod?: string
+}): string {
+    return receiveSettingsScope({
+        amount: values.amount,
+        from: values.from?.name,
+        fromCurrency: values.fromAsset?.symbol,
+        to: values.to?.name,
+        toCurrency: values.toAsset?.symbol,
+        depositMethod: values.depositMethod,
+    })
+}
+
+// Compare canonical token identifiers, independently of the selected networks.
+export function isTokenSwap(sourceToken: string | undefined, destinationToken: string | undefined): boolean {
+    return !!sourceToken && !!destinationToken && sourceToken !== destinationToken
+}
+
+export function resolveReceiveSettings(settings: ReceiveSettings, scope: string, supportsSlippage: boolean): ReceiveSettings {
+    if (!supportsSlippage) return AUTO_RECEIVE_SETTINGS
+    return settings.mode === 'minimum' && settings.scope !== scope ? AUTO_RECEIVE_SETTINGS : settings
+}
+
+const DECIMAL = /^(?:\d+(?:\.\d*)?|\.\d+)$/
+
+export function receiveSettingsError(settings: ReceiveSettings): string | undefined {
+    if (settings.mode === 'auto') return undefined
+    if (settings.mode === 'slippage') {
+        const percent = Number(settings.percent)
+        if (!DECIMAL.test(settings.percent) || !Number.isFinite(percent) || percent < 0.1 || percent > 5) {
+            return 'Slippage must be between 0.1% and 5%.'
+        }
+        return undefined
+    }
+
+    if (!DECIMAL.test(settings.amount) || !Number.isFinite(Number(settings.amount)) || !/[1-9]/.test(settings.amount)) {
+        return 'Enter a minimum receive amount greater than zero.'
+    }
+    const fraction = (settings.amount.split('.')[1] ?? '').replace(/0+$/, '')
+    if (fraction.length > settings.precision) {
+        return `Minimum receive supports up to ${settings.precision} decimal places.`
+    }
+    return undefined
+}
+
+export type ReceiveRequestParams =
+    | { slippage: string; min_receive_amount?: never }
+    | { min_receive_amount: string; slippage?: never }
+    | { slippage?: never; min_receive_amount?: never }
+
+// Shared by quote and create-swap: only send the input the user selected.
+export function receiveRequestParams(settings: ReceiveSettings): ReceiveRequestParams {
+    const error = receiveSettingsError(settings)
+    if (error) throw new Error(error)
+    if (settings.mode === 'minimum') return { min_receive_amount: settings.amount }
+    if (settings.mode === 'slippage') return { slippage: String(Number(settings.percent) / 100) }
+    return {}
+}
+
+// Expand scientific notation from numeric API responses without rounding up a floor.
+export function quotedMinimumInput(amount: number | undefined): string {
+    if (amount === undefined || !Number.isFinite(amount)) return ''
+    const [coefficient, exponent] = String(amount).split('e')
+    if (exponent === undefined) return coefficient
+    const [whole, fraction = ''] = coefficient.split('.')
+    const digits = whole + fraction
+    const point = whole.length + Number(exponent)
+    if (point <= 0) return `0.${'0'.repeat(-point)}${digits}`
+    if (point >= digits.length) return digits + '0'.repeat(point - digits.length)
+    return `${digits.slice(0, point)}.${digits.slice(point)}`
+}

--- a/packages/widget/core/src/stores/slippageStore.ts
+++ b/packages/widget/core/src/stores/slippageStore.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand'
+import { AUTO_RECEIVE_SETTINGS, type ReceiveSettings } from '../lib/receiveSettings'
 
 type SlippageState = {
+    receiveSettings: ReceiveSettings
+    revision: number
+    setReceiveSettings: (value: ReceiveSettings) => void
+    resetMinimumForScope: (scope: string) => void
     slippage: number | undefined
     autoSlippage: boolean
     setSlippage: (value: number | undefined) => void
@@ -8,12 +13,21 @@ type SlippageState = {
     clearSlippage: () => void
 }
 
+const selectionState = (receiveSettings: ReceiveSettings, revision: number) => ({
+    receiveSettings,
+    revision,
+    slippage: receiveSettings.mode === 'slippage' ? Number(receiveSettings.percent) / 100 : undefined,
+    autoSlippage: receiveSettings.mode === 'auto',
+})
+
 export const useSlippageStore = create<SlippageState>()((set) => ({
+    receiveSettings: AUTO_RECEIVE_SETTINGS,
+    revision: 0,
+    setReceiveSettings: (value) => set(state => selectionState(value, state.revision + 1)),
+    resetMinimumForScope: (scope) => set(state => state.receiveSettings.mode === 'minimum' && state.receiveSettings.scope !== scope ? selectionState(AUTO_RECEIVE_SETTINGS, state.revision + 1) : state),
     slippage: undefined,
     autoSlippage: true,
-    setSlippage: (value) => set({ slippage: value }),
-    setAutoSlippage: (value) => set({ autoSlippage: value }),
-    clearSlippage: () => set({ slippage: undefined, autoSlippage: true })
+    setSlippage: (value) => set(state => selectionState(value === undefined ? AUTO_RECEIVE_SETTINGS : { mode: 'slippage', percent: String(value * 100) }, state.revision + 1)),
+    setAutoSlippage: (value) => set(state => selectionState(value ? AUTO_RECEIVE_SETTINGS : state.receiveSettings.mode === 'auto' ? { mode: 'slippage', percent: '' } : state.receiveSettings, state.revision + 1)),
+    clearSlippage: () => set(state => selectionState(AUTO_RECEIVE_SETTINGS, state.revision + 1))
 }))
-
-

--- a/packages/widget/core/tests/receive-settings.test.mjs
+++ b/packages/widget/core/tests/receive-settings.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { registerHooks } from 'node:module'
+import {
+    AUTO_RECEIVE_SETTINGS,
+    formReceiveSettingsScope,
+    isTokenSwap,
+    quotedMinimumInput,
+    receiveRequestParams,
+    receiveSettingsError,
+    receiveSettingsScope,
+    resolveReceiveSettings,
+} from '../src/lib/receiveSettings.ts'
+import { buildQuoteUrl } from '../src/lib/quoteRequest.ts'
+
+// Node strips types; resolve the extensionless relative import used by the store.
+registerHooks({
+    resolve(specifier, context, nextResolve) {
+        try { return nextResolve(specifier, context) }
+        catch (error) {
+            if (error.code === 'ERR_MODULE_NOT_FOUND' && specifier.startsWith('.')) {
+                return nextResolve(`${specifier}.ts`, context)
+            }
+            throw error
+        }
+    },
+})
+const { useSlippageStore } = await import('../src/stores/slippageStore.ts')
+
+const route = { amount: '100', from: 'ETHEREUM_MAINNET', fromCurrency: 'USDC', to: 'ARBITRUM_MAINNET', toCurrency: 'USDT', depositMethod: 'wallet' }
+const scope = receiveSettingsScope(route)
+const minimum = amount => ({ mode: 'minimum', amount, scope, precision: 6 })
+const quoteArgs = { sourceNetwork: route.from, sourceToken: route.fromCurrency, destinationNetwork: route.to, destinationToken: route.toCurrency, amount: route.amount, refuel: true, useDepositAddress: false }
+
+test('minimum and manual slippage each serialize one input through quote and create-swap', () => {
+    for (const settings of [AUTO_RECEIVE_SETTINGS, minimum('98.123456'), { mode: 'slippage', percent: '1.25' }]) {
+        const params = receiveRequestParams(settings)
+        const query = new URLSearchParams(buildQuoteUrl({ ...quoteArgs, slippage: params.slippage === undefined ? undefined : Number(params.slippage), minReceiveAmount: params.min_receive_amount }).split('?')[1])
+        const createBody = JSON.parse(JSON.stringify({ amount: route.amount, ...params }))
+        assert.equal(query.get('amount'), '100')
+        assert.equal(createBody.amount, '100')
+        assert.equal(query.get('min_receive_amount'), createBody.min_receive_amount ?? null)
+        assert.equal(query.get('slippage'), createBody.slippage ?? null)
+        assert.ok(!(query.has('slippage') && query.has('min_receive_amount')))
+        assert.equal(query.get('refuel'), 'true')
+        assert.equal(query.get('use_deposit_address'), 'false')
+    }
+    assert.deepEqual(receiveRequestParams({ mode: 'slippage', percent: '1.25' }), { slippage: '0.0125' })
+})
+
+test('quote URL cannot send conflicting explicit fields and retains address/gasless flags', () => {
+    const query = new URLSearchParams(buildQuoteUrl({ ...quoteArgs, slippage: 0.01, minReceiveAmount: '98', sourceAddress: 'source', destinationAddress: 'destination', useGasless: true }).split('?')[1])
+    assert.equal(query.get('min_receive_amount'), '98')
+    assert.equal(query.has('slippage'), false)
+    assert.equal(query.get('source_address'), 'source')
+    assert.equal(query.get('destination_address'), 'destination')
+    assert.equal(query.get('use_gasless'), 'true')
+})
+
+test('minimum text survives refreshes; selecting slippage or Auto clears it', () => {
+    const store = useSlippageStore.getState()
+    store.setReceiveSettings(minimum('98.123456'))
+    const minimumRevision = useSlippageStore.getState().revision
+    for (let i = 0; i < 3; i++) {
+        useSlippageStore.getState().resetMinimumForScope(scope)
+        assert.deepEqual(receiveRequestParams(useSlippageStore.getState().receiveSettings), { min_receive_amount: '98.123456' })
+        assert.equal(useSlippageStore.getState().revision, minimumRevision)
+    }
+    store.setSlippage(0.025)
+    assert.deepEqual(receiveRequestParams(useSlippageStore.getState().receiveSettings), { slippage: '0.025' })
+    assert.equal(useSlippageStore.getState().autoSlippage, false)
+    store.clearSlippage()
+    assert.deepEqual(receiveRequestParams(useSlippageStore.getState().receiveSettings), {})
+    assert.equal(useSlippageStore.getState().autoSlippage, true)
+    assert.ok(useSlippageStore.getState().revision > minimumRevision, 'returning to Auto must request a fresh quote')
+})
+
+test('amount, token, network and deposit-method changes reset the minimum before a new request', () => {
+    for (const change of [{ amount: '101' }, { from: 'BASE_MAINNET' }, { fromCurrency: 'ETH' }, { to: 'BASE_MAINNET' }, { toCurrency: 'USDC' }, { depositMethod: 'deposit_address' }]) {
+        const changedScope = receiveSettingsScope({ ...route, ...change })
+        const changedRoute = { ...route, ...change }
+        assert.deepEqual(resolveReceiveSettings(minimum('98'), changedScope, isTokenSwap(changedRoute.fromCurrency, changedRoute.toCurrency)), AUTO_RECEIVE_SETTINGS)
+        useSlippageStore.getState().setReceiveSettings(minimum('98'))
+        useSlippageStore.getState().resetMinimumForScope(changedScope)
+        useSlippageStore.getState().resetMinimumForScope(scope)
+        assert.deepEqual(useSlippageStore.getState().receiveSettings, AUTO_RECEIVE_SETTINGS, 'returning to the old pair must not revive its minimum')
+    }
+    assert.equal(receiveSettingsScope({ ...route, amount: '0100.000' }), scope)
+    assert.equal(receiveSettingsScope({ ...route, amount: '.5' }), receiveSettingsScope({ ...route, amount: '0.5' }))
+    assert.equal(receiveSettingsScope({ ...route, amount: 1e-7 }), receiveSettingsScope({ ...route, amount: '0.0000001' }))
+    assert.equal(formReceiveSettingsScope({ amount: '100', from: { name: route.from }, fromAsset: { symbol: route.fromCurrency }, to: { name: route.to }, toAsset: { symbol: route.toCurrency }, depositMethod: 'wallet' }), scope)
+})
+
+test('manual slippage remains selected when amounts or tokens change', () => {
+    useSlippageStore.getState().setSlippage(0.01)
+    useSlippageStore.getState().resetMinimumForScope('different route')
+    assert.deepEqual(receiveRequestParams(useSlippageStore.getState().receiveSettings), { slippage: '0.01' })
+    useSlippageStore.getState().clearSlippage()
+})
+
+test('same-token transfers ignore minimum and slippage, including invalid saved input', () => {
+    const sameTokenScope = receiveSettingsScope({ ...route, toCurrency: 'USDC' })
+    assert.equal(isTokenSwap('USDC', 'USDC'), false)
+    assert.equal(isTokenSwap('USDC', undefined), false)
+    assert.equal(isTokenSwap(undefined, 'USDT'), false)
+    assert.equal(isTokenSwap('USDC', 'USDT'), true)
+    for (const settings of [minimum('98'), { ...minimum('98'), scope: sameTokenScope }, { mode: 'slippage', percent: '1' }, { mode: 'slippage', percent: '' }]) {
+        const resolved = resolveReceiveSettings(settings, sameTokenScope, isTokenSwap('USDC', 'USDC'))
+        assert.deepEqual(resolved, AUTO_RECEIVE_SETTINGS)
+        assert.equal(receiveSettingsError(resolved), undefined)
+        assert.deepEqual(receiveRequestParams(resolved), {})
+    }
+    const manual = { mode: 'slippage', percent: '1' }
+    assert.deepEqual(receiveRequestParams(resolveReceiveSettings(manual, scope, isTokenSwap('USDC', 'USDT'))), { slippage: '0.01' })
+})
+
+test('minimum validation respects quote precision, including zero decimals and exact 18-decimal strings', () => {
+    for (const amount of ['', '.', '0', '0.000000', '-1', 'NaN', 'Infinity', '1e-6', '1,23', ' 1 ', '1.2345678']) {
+        assert.ok(receiveSettingsError(minimum(amount)), amount)
+        assert.throws(() => receiveRequestParams(minimum(amount)))
+    }
+    for (const amount of ['0.000001', '98.123456', '98.123456000', '.5', '1.']) {
+        assert.equal(receiveSettingsError(minimum(amount)), undefined, amount)
+    }
+    assert.equal(receiveSettingsError({ ...minimum('1'), precision: 0 }), undefined)
+    assert.ok(receiveSettingsError({ ...minimum('1.1'), precision: 0 }))
+    const exact = { ...minimum('0.123456789012345678'), precision: 18 }
+    assert.deepEqual(receiveRequestParams(exact), { min_receive_amount: '0.123456789012345678' })
+})
+
+test('invalid slippage is blocked until edited or Auto is selected', () => {
+    for (const percent of ['', '0', '0.09', '5.01', '-1', 'NaN', 'Infinity', '1e1']) {
+        const selection = { mode: 'slippage', percent }
+        assert.ok(receiveSettingsError(selection), percent)
+        assert.throws(() => receiveRequestParams(selection))
+    }
+    for (const percent of ['0.1', '1', '5']) assert.equal(receiveSettingsError({ mode: 'slippage', percent }), undefined)
+    assert.deepEqual(receiveRequestParams(AUTO_RECEIVE_SETTINGS), {})
+})
+
+test('quoted minimum input expands tiny token amounts without rounding the floor', () => {
+    assert.equal(quotedMinimumInput(0.000000000000000001), '0.000000000000000001')
+    assert.equal(quotedMinimumInput(9.975e-6), '0.000009975')
+    assert.equal(quotedMinimumInput(1e21), '1000000000000000000000')
+    assert.equal(quotedMinimumInput(98.123456), '98.123456')
+    assert.equal(quotedMinimumInput(undefined), '')
+})


### PR DESCRIPTION
Allow users to edit “Receive at least” in the destination token, after fees, on the first swap screen when swapping different tokens. Keep Auto and manual slippage, seed the editor from the quoted minimum, and leave the send amount unchanged. Quote and create-swap requests send only the selected input: `min_receive_amount`, `slippage`, or neither for Auto.

Preserve an entered minimum during quote refreshes and clear it when the amount or token pair changes. Opening an editor no longer requests a new quote or shifts the layout; estimates stay visible during edits while submission waits for a valid quote. Validation and no-quote states keep the controls accessible. Same-token transfers show a read-only minimum, hide slippage controls, and omit both settings from requests.

Validation:

- `pnpm --filter @layerswap/widget test` — 9 tests passed.
- `pnpm --filter @layerswap/widget exec tsc --project tsconfig.json --types node` — passed; widget output rebuilt.
- Temporary DOM integration harness with mocked quote/create APIs at 1280px and 375px: edits, opening without requoting, Auto, refresh persistence, unchanged send amount in USD mode, invalid/no-quote recovery, same-token restrictions, route changes, late responses, and create-swap payloads passed.
- Browser visual QA and live wallet transactions still need verification.

Closes [BAB-338](https://linear.app/layerswap/issue/BAB-338/allow-editing-min-receive-on-the-first-swap-screen). Uses the API support from [BAB-337](https://linear.app/layerswap/issue/BAB-337/support-setting-min-receive-in-the-quote-and-create-swap-apis).
