### PR TITLE
fix(stellar): pin mainnet endpoints (main hotfix)

### DIFF
--- a/packages/wallets/adapters/stellar/src/stellarServers.ts
+++ b/packages/wallets/adapters/stellar/src/stellarServers.ts
@@ -6,7 +6,13 @@ type StellarServer = Horizon.Server | rpc.Server
 const horizonServers = new Map<string, Promise<Horizon.Server>>()
 const rpcServers = new Map<string, Promise<rpc.Server>>()
 
-function getCandidateUrls(network: Network): string[] {
+function getCandidateUrls(network: Network, kind: 'Horizon' | 'RPC'): string[] {
+    // Pin mainnet endpoints by protocol so public-node health flags cannot hide either API.
+    if (network.name === 'STELLAR_MAINNET') {
+        return kind === 'Horizon'
+            ? ['https://horizon.stellar.org']
+            : ['https://mainnet.sorobanrpc.com']
+    }
     return [...new Set([network.node_url, ...(network.nodes ?? [])].filter(Boolean))]
 }
 
@@ -16,7 +22,7 @@ async function findServer<T extends StellarServer>(
     kind: 'Horizon' | 'RPC',
     createAndVerify: (url: string) => Promise<T>,
 ): Promise<T> {
-    const candidates = getCandidateUrls(network)
+    const candidates = getCandidateUrls(network, kind)
     if (candidates.length === 0) {
         throw new Error(`No Stellar ${kind} endpoints are configured for ${network.name}`)
     }
@@ -42,7 +48,7 @@ function cachedServer<T>(cache: Map<string, Promise<T>>, key: string, load: () =
 }
 
 export function getStellarHorizonServer(network: Network, networkPassphrase: string): Promise<Horizon.Server> {
-    const key = `${network.name}:${networkPassphrase}:${getCandidateUrls(network).join('|')}`
+    const key = `${network.name}:${networkPassphrase}:${getCandidateUrls(network, 'Horizon').join('|')}`
     return cachedServer(horizonServers, key, () => findServer(
         network,
         networkPassphrase,
@@ -59,7 +65,7 @@ export function getStellarHorizonServer(network: Network, networkPassphrase: str
 }
 
 export function getStellarRpcServer(network: Network, networkPassphrase: string): Promise<rpc.Server> {
-    const key = `${network.name}:${networkPassphrase}:${getCandidateUrls(network).join('|')}`
+    const key = `${network.name}:${networkPassphrase}:${getCandidateUrls(network, 'RPC').join('|')}`
     return cachedServer(rpcServers, key, () => findServer(
         network,
         networkPassphrase,

--- a/packages/wallets/adapters/stellar/tests/stellar.test.mjs
+++ b/packages/wallets/adapters/stellar/tests/stellar.test.mjs
@@ -446,6 +446,48 @@ test('maps spendable Horizon balances like the backend', () => {
     assert.equal(baseUnitsToNumber(100n, 7), 0.00001)
 })
 
+test('uses verified mainnet endpoints when backend public nodes are unavailable', async t => {
+    const requests = []
+    let passphrase = Networks.TESTNET
+    t.mock.method(globalThis, 'fetch', async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init)
+        requests.push({ url: request.url, method: request.method })
+        if (request.url === 'https://horizon.stellar.org/' && request.method === 'GET') {
+            return Response.json({ network_passphrase: passphrase })
+        }
+        if (request.url === 'https://mainnet.sorobanrpc.com/' && request.method === 'POST') {
+            const body = await request.json()
+            assert.equal(body.method, 'getNetwork')
+            return Response.json({ jsonrpc: '2.0', id: body.id, result: { passphrase, protocolVersion: 27 } })
+        }
+        assert.fail(`Unexpected Stellar request: ${request.method} ${request.url}`)
+    })
+    const network = {
+        name: 'STELLAR_MAINNET',
+        node_url: 'https://horizon.stellar.org',
+        nodes: [],
+    }
+
+    // A reachable endpoint on the wrong chain must still be rejected.
+    await assert.rejects(getStellarHorizonServer(network, Networks.PUBLIC), /No Stellar Horizon endpoint/)
+    await assert.rejects(getStellarRpcServer(network, Networks.PUBLIC), /No Stellar RPC endpoint/)
+
+    // Failed verification must not prevent a later successful retry.
+    passphrase = Networks.PUBLIC
+    const [horizon, rpcServer] = await Promise.all([
+        getStellarHorizonServer(network, Networks.PUBLIC),
+        getStellarRpcServer(network, Networks.PUBLIC),
+    ])
+    assert.equal(horizon.serverURL.toString(), 'https://horizon.stellar.org/')
+    assert.equal(rpcServer.serverURL.toString(), 'https://mainnet.sorobanrpc.com/')
+    assert.deepEqual(requests, [
+        { url: 'https://horizon.stellar.org/', method: 'GET' },
+        { url: 'https://mainnet.sorobanrpc.com/', method: 'POST' },
+        { url: 'https://horizon.stellar.org/', method: 'GET' },
+        { url: 'https://mainnet.sorobanrpc.com/', method: 'POST' },
+    ])
+})
+
 test('discovers Horizon and RPC from the backend network node list', async () => {
     const originalFetch = globalThis.fetch
     const requests = []


### PR DESCRIPTION
Cherry-pick only the Stellar mainnet fix from #2163 (commit `0d71b0cf0`) onto `main`; this branch contains one commit and changes only the adapter endpoint selection and its regression test.

Pin Horizon to `https://horizon.stellar.org` and RPC to `https://mainnet.sorobanrpc.com` so incorrect backend health flags cannot prevent mainnet transfers, while retaining passphrase verification and existing testnet discovery.

The patch matches the dev fix exactly and includes no other dev changes.

Validation: the original fix passed dependency and adapter builds plus all 16 Stellar tests on Node 24; relevant source and lockfile match that tested version, and `git diff --check` passes on this branch.
